### PR TITLE
Print paths to html template used

### DIFF
--- a/emfacilities/__init__.py
+++ b/emfacilities/__init__.py
@@ -32,7 +32,7 @@ import pwem
 
 from .constants import *
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 _logo = "scipion_icon.gif"
 _references = ["delaRosaTrevin201693"]
 

--- a/emfacilities/protocols/protocol_monitor_2d_streamer.py
+++ b/emfacilities/protocols/protocol_monitor_2d_streamer.py
@@ -148,7 +148,7 @@ class ProtMonitor2dStreamer(ProtMonitor):
             micId = particle.getMicId()
             partId = particle.getObjId()
             subset.append(particle)
-            self.info("micId: %03d, particle: %05s, size: %s"
+            self.debug("micId: %03d, particle: %05s, size: %s"
                       % (micId, partId, subset.getSize()))
 
             # Check the following after finding particles of a new micrograph

--- a/emfacilities/protocols/report_html.py
+++ b/emfacilities/protocols/report_html.py
@@ -96,12 +96,14 @@ class ReportHtml:
         """ Returns the path of the customized template at
         config/execution.summary.html or the standard scipion HTML template"""
         # Try if there is a customized template
-        template = os.path.join(basename(pwutils.Config.SCIPION_CONFIG),
+        template = os.path.join(os.path.dirname(pwutils.Config.SCIPION_CONFIG),
                                 'execution.summary.html')
 
         if not os.path.exists(template):
+            print("Customized HTML template not found at %s." % template)
             template = os.path.join(Plugin.getPluginTemplateDir(),
                                     'execution.summary.template.html')
+            print("Using provided one at %s." % template)
         else:
             print("Customized HTML template found at %s." % template)
         return template


### PR DESCRIPTION
send 2d streamer debug lines to debug
Fix: use custom path for html template.