### PR TITLE
make system monitor viewer interactive again

### DIFF
--- a/emfacilities/viewers/viewer_monitors.py
+++ b/emfacilities/viewers/viewer_monitors.py
@@ -492,8 +492,7 @@ class SystemMonitorPlotter(EmPlotter):
         self.ax.legend()
         anim = animation.FuncAnimation(
             self.fig, animate,
-            interval=1000)  # miliseconds
-#            interval=self.monitor.samplingInterval * 1000)  # miliseconds
+            interval=self.monitor.samplingInterval * 1000)  # miliseconds
 
 
         self.fig.canvas.mpl_connect('scroll_event', on_scroll)

--- a/emfacilities/viewers/viewer_monitors.py
+++ b/emfacilities/viewers/viewer_monitors.py
@@ -442,8 +442,8 @@ class SystemMonitorPlotter(EmPlotter):
 
 
     def animate(self, i=0):  # do NOT remove i, i is a counter
-                             # each call to animate sends increases the
-                             # value by 1. It is not used here but
+                             # each call to animate  increases the
+                             # value of i by 1. 'i' is not used here but
                              # is a mandatory argument to the function
         if self.stop:
             return


### PR DESCRIPTION
Once upon the time the plot showing the monitor data was interactive and animated. That is, by pressing certain keys it showed or hid some of the data plotted and the plot was re-ploted each few seconds.  At some point in the past these properties were lost. I have modified the code for the "system monitor" so interactivity is back.  No modification has been made for the other monitors although I guess the same changes  need to be applied to them.

Since this is a viewer no test has been added. In order to test this you may create a minimal project with "import particles in streaming" and "system monitor" and visualize system monitor. By pressing the keys "c", "d", "n" information related with "cpu", "disk" and "network" should dissappear/appear. Plot should repaint each few seconds
 