### PR TITLE
monitor summary: added  rate colum for each protocol

### DIFF
--- a/emfacilities/protocols/protocol_monitor.py
+++ b/emfacilities/protocols/protocol_monitor.py
@@ -56,6 +56,10 @@ class ProtMonitor(EMProtocol):
                       label="Sampling Interval (sec)",
                       help="Take one sample each *samplingInterval* seconds")
 
+        form.addParam('monitorTime', params.FloatParam, default=34560,
+                      label="Total Logging time (min)",
+                      help="Log during this interval. 21 days by default")
+
     def _sendMailParams(self, form):
         g = form.addGroup('Email settings')
 

--- a/emfacilities/protocols/protocol_monitor_summary.py
+++ b/emfacilities/protocols/protocol_monitor_summary.py
@@ -144,7 +144,7 @@ class ProtMonitorSummary(ProtMonitor):
                       default=False,
                       help="Use grafana+influx vs apache for reports")
         form.addParam('publishCmd', params.StringParam, default='',
-                      condition='doInflux == False',
+                      condition='doInflux == True',
                       label="Publish command",
                       help="Specify a command to publish the template. "
                            "You can use the special token %(REPORT_FOLDER)s "

--- a/emfacilities/protocols/protocol_monitor_summary.py
+++ b/emfacilities/protocols/protocol_monitor_summary.py
@@ -214,6 +214,12 @@ class ProtMonitorSummary(ProtMonitor):
         # create report dir
         pwutils.makePath(self.reportDir)
 
+        pathRepoSummary = self._getPath("pathRepo.txt")
+        pathRepoSummary = open(pathRepoSummary, "w")
+        pathRepoSummary.write("HTML path to summary: " + self.reportPath)
+        pathRepoSummary.close()
+
+
     def _getAlignProtocol(self):
         for protPointer in self.inputProtocols:
             prot = protPointer.get()
@@ -324,3 +330,14 @@ class ProtMonitorSummary(ProtMonitor):
             htmlReport.setUp()
 
         return htmlReport
+    def _summary(self):
+        summary = []
+        pathRepoSummary = self._getPath("pathRepo.txt")
+        if not os.path.exists(pathRepoSummary):
+            summary.append("No summary file yet.")
+        else:
+            pathRepoSummary = open(pathRepoSummary, "r")
+            for line in pathRepoSummary.readlines():
+                summary.append(line.rstrip())
+            pathRepoSummary.close()
+        return summary

--- a/emfacilities/protocols/protocol_monitor_summary.py
+++ b/emfacilities/protocols/protocol_monitor_summary.py
@@ -91,9 +91,7 @@ class ProtMonitorSummary(ProtMonitor):
                       help="Raise alarm if astigmatism (defocusU-defocusV)is greater than given "
                            "value")
 
-        form.addParam('monitorTime', params.FloatParam, default=30000,
-                      label="Total Logging time (min)",
-                      help="Log during this interval")
+
 
         form.addSection('System Monitor')
         form.addParam('cpuAlert', params.FloatParam, default=101,

--- a/emfacilities/protocols/protocol_monitor_summary.py
+++ b/emfacilities/protocols/protocol_monitor_summary.py
@@ -144,7 +144,6 @@ class ProtMonitorSummary(ProtMonitor):
                       default=False,
                       help="Use grafana+influx vs apache for reports")
         form.addParam('publishCmd', params.StringParam, default='',
-                      condition='doInflux == True',
                       label="Publish command",
                       help="Specify a command to publish the template. "
                            "You can use the special token %(REPORT_FOLDER)s "

--- a/emfacilities/protocols/report_html.py
+++ b/emfacilities/protocols/report_html.py
@@ -149,7 +149,7 @@ class ReportHtml:
                 and self.alignProtocol._doComputeMicThumbnail()):
             self.micThumbSymlinks = True
 
-    def getThumbPaths(self, thumbsDone=0, ctfData=None, ext='png', micIdSet=None):
+    def getThumbPaths(self, thumbsDone=0, ctfData=None, ext='jpg', micIdSet=None):
         """Adds to self.thumbPaths the paths to the report thumbnails
            that come from the alignment and/or ctf protocol.
 
@@ -271,9 +271,7 @@ class ReportHtml:
                 if self.micThumbSymlinks:
                     pwutils.copyFile(self.thumbPaths[MIC_PATH][i], dstImgPath)
                 else:
-                    ih.computeThumbnail(self.thumbPaths[MIC_PATH][i],
-                                        dstImgPath, scaleFactor=micScaleFactor,
-                                        flipOnY=True)
+                    ih.convert(self.thumbPaths[MIC_PATH][i], pwutils.replaceExt(dstImgPath, "jpg"))
 
             # shift plots
             if SHIFT_THUMBS in self.thumbPaths:
@@ -293,15 +291,13 @@ class ReportHtml:
                             psdImg1 = ih.read(srcImgPath)
                             psdImg1.convertPSD()
                             psdImg1.write(dstImgPath)
-                            ih.computeThumbnail(dstImgPath, dstImgPath,
-                                                scaleFactor=1, flipOnY=True)
+                            ih.convert(dstImgPath, pwutils.replaceExt(dstImgPath, "jpg"))
                         else:
                             pwutils.copyFile(srcImgPath, dstImgPath)
                 else:
                     dstImgPath = join(self.reportDir, self.thumbPaths[PSD_THUMBS][i])
                     if not exists(dstImgPath):
-                        ih.computeThumbnail(self.thumbPaths[PSD_PATH][i],
-                                            dstImgPath, scaleFactor=1, flipOnY=True)
+                        ih.convert(self.thumbPaths[PSD_PATH][i], pwutils.replaceExt(dstImgPath, "jpg"))
 
         return
 

--- a/emfacilities/protocols/report_html.py
+++ b/emfacilities/protocols/report_html.py
@@ -352,24 +352,21 @@ class ReportHtml:
             diffItemsAdded.append(float(itemsAdded[-1] - itemsAdded[-2]))
             medianDiffItems = mean(diffItemsAdded[:-1])
             threshold = self.thresholdRate * medianDiffItems
-            threshold = self.thresholdRate * medianDiffItems
             if medianDiffItems + threshold < diffItemsAdded[-1]:
-                print(medianDiffItems - threshold, diffItemsAdded[-1] )
                 statusRate = '<b> ↑ </b>'
+                #statusRate = '<b style="color:#15c51f";> ↑ </b>' #Why does it not work???
             elif medianDiffItems - threshold > diffItemsAdded[-1]:
-                print(medianDiffItems - threshold, diffItemsAdded[-1] )
                 statusRate = '<b> ↓  </b>'
             else:
-                print(medianDiffItems - threshold, diffItemsAdded[-1] )
                 statusRate = '<b> -  </b>'
             rateFreq = round(diffItemsAdded[-1] * self.one_minute_freq_operator, 2)
             rate, statusRate = self.estimateTimeRate(rateFreq, statusRate)
-            print('itemsAdded: {}\ndiffItemsAdded: {}\nmedianDiffItems: {} threshold:{}\nrateFreq: {}, rate: {}, statusRate: {}\n'.format(
-                itemsAdded, diffItemsAdded, medianDiffItems, threshold, rateFreq, rate, statusRate))
+            # print('itemsAdded: {}\ndiffItemsAdded: {}\nmedianDiffItems: {} threshold:{}\nrateFreq: {}, rate: {}, statusRate: {}\n'.format(
+            #     itemsAdded, diffItemsAdded, medianDiffItems, threshold, rateFreq, rate, statusRate))
 
             return rate, statusRate
         except Exception as e:
-            print('e: {}'.format(e))
+            #print('e: {}'.format(e))
             return '-', ' '
 
     def estimateTimeRate(self, diffItem, statusRate):
@@ -469,7 +466,7 @@ class ReportHtml:
                     elif protocolName.find("Align") != -1 or\
                         protocolName.find("align") != -1:
                         if obj.output.find("outputMicrographs") != -1:
-                            print('obj.output: {}'.format(obj.output))
+                            #print('obj.output: {}'.format(obj.output))
                             self.itemsAddedAlign.append(obj.outSize)
                         rate, statusRate = self.rateCalculation('Align')
                     else:

--- a/emfacilities/protocols/report_html.py
+++ b/emfacilities/protocols/report_html.py
@@ -358,7 +358,7 @@ class ReportHtml:
             elif medianDiffItems - threshold > diffItemsAdded[-1]:
                 statusRate = '<b> ↓  </b>'
             else:
-                statusRate = '<b> -  </b>'
+                statusRate = '<b> --  </b>'
             rateFreq = round(diffItemsAdded[-1] * self.one_minute_freq_operator, 2)
             rate, statusRate = self.estimateTimeRate(rateFreq, statusRate)
             # print('itemsAdded: {}\ndiffItemsAdded: {}\nmedianDiffItems: {} threshold:{}\nrateFreq: {}, rate: {}, statusRate: {}\n'.format(

--- a/emfacilities/protocols/report_influx.py
+++ b/emfacilities/protocols/report_influx.py
@@ -444,37 +444,18 @@ class ReportInflux:
                 tags['section'] = 'ctf'
                 pointsDict = {}
                 source.append(point['shiftPlotPathLocal']) # shift plot
-                source.append(point['psdPathLocalPng'])    # psd image
-                source.append(point['micPathLocalPng'])    # micrograph
+                source.append(pwutils.replaceExt(point['psdPathLocalPng'], 'jpg'))    # psd image
+                source.append(pwutils.replaceExt(point['micPathLocalPng'], 'jpg'))    # micrograph
 
-                # default value 512
-                try:
-                    X, Y, Z, N = self.ih.getDimensions(point['psdPathLocal'])
-                except:
-                    print("file %s does not exist"% point['psdPathLocal'])
-                if X > 512:
-                    scaleFactor = X // 512
-                else:
-                    scaleFactor = 1
+                self.ih.convert(point['psdPathLocal'], pwutils.replaceExt(point['psdPathLocalPng'], 'jpg'))
 
-                self.ih.computeThumbnail(point['psdPathLocal'], point['psdPathLocalPng'],
-                                    scaleFactor=scaleFactor, flipOnY=True)
-
-                X, Y, Z, N = self.ih.getDimensions(point['micPathLocal'])
-                if X > 512:
-                    scaleFactor = X // 512
-                else:
-                    scaleFactor = 1
-                self.ih.computeThumbnail(point['micPathLocal'], point['micPathLocalPng'],
-                                    scaleFactor=scaleFactor, flipOnY=True)
+                self.ih.convert(point['micPathLocal'], pwutils.replaceExt(point['micPathLocalPng'], 'jpg'))
 
                 # add files to transfer list
                 target.append(os.path.join(self.projectName,
                                            basename(point['shiftPlotPathLocal'])))
-                target.append(os.path.join(self.projectName,
-                                           basename(point['psdPathLocalPng'])))
-                target.append(os.path.join(self.projectName,
-                                           basename(point['micPathLocalPng'])))
+                target.append(os.path.join(self.projectName, basename(pwutils.replaceExt(point['psdPathLocalPng'], 'jpg'))))
+                target.append(os.path.join(self.projectName, basename(pwutils.replaceExt(point['micPathLocalPng'], 'jpg'))))
                 #
                 point['transferImage'] = True
                 pointsDict['time'] = point['time']
@@ -482,6 +463,8 @@ class ReportInflux:
                 del point['time']
                 del point['section']
                 del point['id']
+                point['micPath'] = point['micPath'].replace('.png', '.jpg')
+                point['psdPath'] = point['psdPath'].replace('.png', '.jpg')
                 pointsDict['fields'] = point
                 pointsDict['tags'] = tags
                 pointsDict['measurement'] = self.projectName

--- a/emfacilities/templates/execution.summary.template.html
+++ b/emfacilities/templates/execution.summary.template.html
@@ -247,6 +247,7 @@
                             <TH>Name</TH>
                             <TH>Output</TH>
                             <TH>Number</TH>
+                            <TH>Rate</TH>
                         </TR>
                     </TABLE>
                 </DIV>
@@ -349,11 +350,11 @@
 
             // For each protocol property
             $.each(report.runs, function(index, value){
-                var line = "<TR class='protocolLine'><TD>" + value.protocolName + "</TD><TD colspan='2'></TD></TR>";
+                var line = "<TR class='protocolLine'><TD>" + value.protocolName + "</TD><TD colspan='3'></TD></TR>";
                 $(runsTable).append(line);
 
                 $.each(value.output, function(index, value){
-                    var outputLine = "<TR><TD></TD><TD>" + value.name + "</TD><TD class='center'>" + value.size + "</TD></TR>";
+                    var outputLine = "<TR><TD></TD><TD>" + value.name + "</TD><TD class='center'>" + value.size + "</TD><TD>" + value.rate + "</TD></TR>";
                     $(runsTable).append(outputLine);
 
                 });


### PR DESCRIPTION
With the update, the user will see the rate of outputs for each protocol associated to the monitor summary one.
![image](https://user-images.githubusercontent.com/12760268/211825281-c7845818-eed9-4111-ae73-e292dd32d3a1.png)

If the number of movies added in the last minute is higher than the mean (plus a threshold of 10% based on the mean) will be printed a ↑, if lower  ↓ or -  if equal. For all case the rate will be printed

Added the path for the html in the summary