### PR TITLE
New streaming protocols: Data counter and Data sampler

### DIFF
--- a/emfacilities/protocols.conf
+++ b/emfacilities/protocols.conf
@@ -30,7 +30,8 @@ Protocols SPA = [
 	{"tag": "section", "text": "Tools", "openItem": "False", "children": [
 		{"tag": "protocol_group", "text": "Sets", "openItem": "False", "children": [
 		    {"tag": "protocol", "value": "ProtVolumeExtractor", "text": "default"},
-		    {"tag": "protocol", "value": "ProtDataSampler", "text": "default"}
+		    {"tag": "protocol", "value": "ProtDataSampler", "text": "default"},
+		    {"tag": "protocol", "value": "ProtDataCounter", "text": "default"}
 		]},
 		{"tag": "protocol_group", "text": "Calculators", "openItem": "False", "children": []}
 	]}]

--- a/emfacilities/protocols.conf
+++ b/emfacilities/protocols.conf
@@ -29,7 +29,8 @@ Protocols SPA = [
 	{"tag": "section", "text": "Resolution", "openItem": "False", "children": []},
 	{"tag": "section", "text": "Tools", "openItem": "False", "children": [
 		{"tag": "protocol_group", "text": "Sets", "openItem": "False", "children": [
-		    {"tag": "protocol", "value": "ProtVolumeExtractor", "text": "default"}
+		    {"tag": "protocol", "value": "ProtVolumeExtractor", "text": "default"},
+		    {"tag": "protocol", "value": "ProtDataSampler", "text": "default"}
 		]},
 		{"tag": "protocol_group", "text": "Calculators", "openItem": "False", "children": []}
 	]}]

--- a/emfacilities/protocols/__init__.py
+++ b/emfacilities/protocols/__init__.py
@@ -1,5 +1,6 @@
 
 
+from .protocol_data_sampler import ProtDataSampler
 from .protocol_monitor import ProtMonitor, Monitor, PrintNotifier
 from .protocol_monitor_system import SYSTEM_LOG_SQLITE
 

--- a/emfacilities/protocols/__init__.py
+++ b/emfacilities/protocols/__init__.py
@@ -1,5 +1,5 @@
 
-
+from .protocol_data_counter import ProtDataCounter
 from .protocol_data_sampler import ProtDataSampler
 from .protocol_monitor import ProtMonitor, Monitor, PrintNotifier
 from .protocol_monitor_system import SYSTEM_LOG_SQLITE

--- a/emfacilities/protocols/protocol_data_counter.py
+++ b/emfacilities/protocols/protocol_data_counter.py
@@ -251,14 +251,14 @@ class ProtDataCounter(EMProtocol):
             self.delayRegister()
             if self.boolTimer.get():
                 self.info('Using timer:')
-                self.waitingStep()
+                self.timerStep()
 
     def delayRegister(self):
         delay = self.delay.get()
         self.info('Sleeping for delay time: %d' %delay)
         time.sleep(delay)
 
-    def waitingStep(self):
+    def timerStep(self):
         endTime = self.lastTimeCheckTimer + timedelta(seconds=self.timeoutSecs)
         now = datetime.now()
         remainingTime = (endTime - now).total_seconds()

--- a/emfacilities/protocols/protocol_data_counter.py
+++ b/emfacilities/protocols/protocol_data_counter.py
@@ -1,0 +1,302 @@
+# **************************************************************************
+# *
+# * Authors: Daniel Marchan (da.marchan@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+import os
+from datetime import datetime, timedelta
+import time
+import copy
+import re
+
+from pwem.protocols import EMProtocol
+from pwem.objects import SetOfImages, Set
+
+from pyworkflow import VERSION_3_0
+import pyworkflow.protocol.params as params
+import pyworkflow.utils as pwutils
+from pyworkflow import UPDATED, NEW
+from pyworkflow.protocol.constants import STATUS_NEW
+
+
+
+OUTPUT = "outputSet"
+
+class ProtDataCounter(EMProtocol):
+    """
+    Protocol to make a subset of images from the original one.
+    Waits until certain number of images is prepared and then send them to output.
+    It can be done in 3 ways:
+        - If simple mode: once the number of items is reached, a setOfImages is returned and
+            the protocol finishes (ending the streaming from this point).
+    The protocol will accept Micrographs, Particles and any kind of object that inherits from Image base class.
+    """
+    _label = 'data counter'
+    _devStatus = NEW
+    _lastUpdateVersion = VERSION_3_0
+    _possibleOutputs = {OUTPUT: SetOfImages}
+
+
+    def __init__(self, **args):
+        EMProtocol.__init__(self, **args)
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputImages', params.PointerParam, pointerClass='SetOfImages',
+                      label="Input images", important=True)
+        form.addParam('outputSize', params.IntParam, default=10000,
+                      label='Output size',
+                      help='How many images need to be on input to '
+                           'create output set.')
+
+        form.addSection(label='Stream of data timer')
+        form.addParam('delay', params.IntParam, default=10, label="Delay (sec)",
+                      validators=[params.GT(2, "must be larger than 3sec.")],
+                      help="Delay in seconds before checking new output")
+        form.addParam('boolTimer', params.BooleanParam, default=False,
+                      label='Use timer?',
+                      help='Select YES if you want to use a timer to close the stream of data once the timer is consumed.\n'
+                           'If NO is selected, normal functionality.\n'
+                           'If the output size is achieved first it will be closed as well.')
+        form.addParam('timeout', params.StringParam, default="1h",
+                      condition="boolTimer==%d" % True,
+                      label='Time to wait:',
+                      help='Time in seconds that the protocol will remain '
+                           'running. A correct format is an integer number in '
+                           'seconds or the following syntax: {days}d {hours}h '
+                           '{minutes}m {seconds}s separated by spaces '
+                           'e.g: 1d 2h 20m 15s,  10m 3s, 1h, 20s or 25.')
+
+
+# --------------------------- INSERT steps functions -------------------------
+    def _insertAllSteps(self):
+        self.initializeParams()
+        self._insertFunctionStep(self.createOutputStep,
+                                 prerequisites=[], wait=True, needsGPU=False)
+
+    def createOutputStep(self):
+        self._closeOutputSet()
+
+    def initializeParams(self):
+        self.finished = False
+        # Important to have both:
+        self.insertedIds = []   # Contains images that have been inserted in a Step (checkNewInput).
+        self.processedIds = [] # Ids to be output
+        self.isStreamClosed = self.inputImages.get().isStreamClosed()
+        # Contains images that have been processed in a Step (checkNewOutput).
+        self.inputFn = self.inputImages.get().getFileName()
+        self._inputClass = self.inputImages.get().getClass()
+        self._inputType = self.inputImages.get().getClassName().split('SetOf')[1]
+        self._baseName = '%s.sqlite' % self._inputType.lower()
+        self.limitReach = False
+        self.timerOut = False
+        self.timeoutSecs = self.getTimeOutInSeconds(self.timeout.get())
+        self.lastTimeCheckTimer = datetime.now() # Timer
+
+    def _getFirstJoinStepName(self):
+        # This function will be used for streaming, to check which is
+        # the first function that need to wait for all ctfs
+        # to have completed, this can be overriden in subclasses
+        # (e.g., in Xmipp 'sortPSDStep')
+        return 'createOutputStep'
+
+    def _getFirstJoinStep(self):
+        for s in self._steps:
+            if s.funcName == self._getFirstJoinStepName():
+                return s
+        return None
+
+    def _stepsCheck(self):
+        self._checkNewInput()
+        self._checkNewOutput()
+
+    def _checkNewInput(self):
+        # Check if there are new images to process from the input set
+        self.lastCheck = getattr(self, 'lastCheck', datetime.now())
+        mTime = datetime.fromtimestamp(os.path.getmtime(self.inputFn))
+        self.debug('Last check: %s, modification: %s'
+                    % (pwutils.prettyTime(self.lastCheck),
+                        pwutils.prettyTime(mTime)))
+        # If the input.sqlite have not changed since our last check,
+        # it does not make sense to check for new input data
+        if self.lastCheck > mTime and self.insertedIds:  # If this is empty it is due to a static "continue" action or it is the first round
+            return None
+
+        inputSet = self._loadInputSet(self.inputFn)
+        inputSetIds = inputSet.getIdSet()
+        newIds = [idImage for idImage in inputSetIds if idImage not in self.insertedIds]
+
+        self.lastCheck = datetime.now()
+        self.isStreamClosed = inputSet.isStreamClosed()
+        inputSet.close()
+
+        outputStep = self._getFirstJoinStep()
+
+        if self.isContinued() and not self.insertedIds:  # For "Continue" action and the first round
+            doneIds, _ = self._getAllDoneIds()
+            skipIds = list(set(newIds).intersection(set(doneIds)))
+            newIds = list(set(newIds).difference(set(doneIds)))
+            self.info("Skipping Images with ID: %s, seems to be done" % skipIds)
+            self.insertedIds = doneIds  # During the first round of "Continue" action it has to be filled
+
+        if newIds and not self.limitReach and not self.timerOut:
+            fDeps = self._insertNewImageSteps(newIds)
+            if outputStep is not None:
+                outputStep.addPrerequisites(*fDeps)
+            self.updateSteps()
+
+    def _checkNewOutput(self):
+        doneListIds, currentOutputSize = self._getAllDoneIds()
+        processedIds = copy.deepcopy(self.processedIds)
+        newDone = [imageId for imageId in processedIds if imageId not in doneListIds]
+        allDone = len(doneListIds) + len(newDone)
+        limitOutputSize = self.outputSize.get()
+        maxSize = self._loadInputSet(self.inputFn).getSize()
+        self.limitReach = allDone >= limitOutputSize
+
+        # We have finished when there is not more input images
+        # (stream closed) or when the limit of output size is met
+        self.finished = (self.isStreamClosed and allDone == maxSize) or (self.limitReach or self.timerOut)
+
+        if not self.finished and not newDone:
+            # If we are not finished and no new output have been produced
+            # it does not make sense to proceed and updated the outputs
+            # so we exit from the function here
+            return
+
+        inputSet = self._loadInputSet(self.inputFn)
+        outputSet = self._loadOutputSet(self._inputClass, self._baseName)
+
+        if currentOutputSize < limitOutputSize:
+            for imageId in newDone:
+                image = inputSet.getItem("id", imageId).clone()
+                outputSet.append(image)
+                currentOutputSize += 1
+                if currentOutputSize == limitOutputSize:
+                    self.finished = True
+                    break # We have reach the limit for the outputSize
+
+            streamMode = Set.STREAM_CLOSED if self.finished else Set.STREAM_OPEN
+
+            self._updateOutputSet(OUTPUT, outputSet, streamMode)
+
+        if self.finished:  # Unlock createOutputStep if finished all jobs
+            outputStep = self._getFirstJoinStep()
+            if outputStep and outputStep.isWaiting():
+                outputStep.setStatus(STATUS_NEW)
+
+        self._store()
+
+    def _loadInputSet(self, inputFn):
+        self.debug("Loading input db: %s" % inputFn)
+        inputSet = self._inputClass(filename=inputFn)
+        inputSet.loadAllProperties()
+        return inputSet
+
+    def _loadOutputSet(self, SetClass, baseName):
+        setFile = self._getPath(baseName)
+
+        if os.path.exists(setFile):
+            outputSet = SetClass(filename=setFile)
+            outputSet.loadAllProperties()
+            outputSet.enableAppend()
+        else:
+            outputSet = SetClass(filename=setFile)
+            outputSet.setStreamState(outputSet.STREAM_OPEN)
+
+        inputs = self.inputImages.get()
+        outputSet.copyInfo(inputs)
+
+        return outputSet
+
+    def _insertNewImageSteps(self, newIds):
+        """ Insert steps to register new images (from streaming)
+        Params:
+            newIds: input images ids to be processed
+        """
+        deps = []
+        stepId = self._insertFunctionStep(self.registerStep, newIds, needsGPU=False,
+                                          prerequisites=[])
+        deps.append(stepId)
+        self.insertedIds.extend(newIds)
+
+        return deps
+
+    def registerStep(self, newIds):
+        self.info('Registering the %d new images' %len(newIds))
+        for imageId in newIds:
+            self.processedIds.append(imageId)
+
+        if not self.isStreamClosed:
+            self.delayRegister()
+            if self.boolTimer.get():
+                self.info('Using timer:')
+                self.waitingStep()
+
+    def delayRegister(self):
+        delay = self.delay.get()
+        self.info('Sleeping for delay time: %d' %delay)
+        time.sleep(delay)
+
+    def waitingStep(self):
+        endTime = self.lastTimeCheckTimer + timedelta(seconds=self.timeoutSecs)
+        now = datetime.now()
+        remainingTime = (endTime - now).total_seconds()
+
+        if remainingTime <= 0:
+            self.timerOut = True
+            self.info("  timer is consumed terminating protocol.")
+        else:
+            self.info(f"  remaining time: {int(remainingTime)} seconds.")
+            self.timeoutSecs = int(remainingTime)
+
+        # Update the last time check
+        self.lastTimeCheckTimer = now
+
+    # ------------------------- UTILS functions --------------------------------
+    def _getAllDoneIds(self):
+        doneIds = []
+        sizeOutput = 0
+
+        if hasattr(self, OUTPUT):
+            sizeOutput = self.outputSet.getSize()
+            doneIds.extend(list(self.outputSet.getIdSet()))
+
+        return doneIds, sizeOutput
+
+    def getTimeOutInSeconds(self, timeOut):
+        timeOutFormatRegexList = {r'\d+s': 1, r'\d+m': 60, r'\d+h': 3600,
+                                  r'\d+d': 72000}
+        try:
+            return int(timeOut)
+        except Exception:
+            seconds = 0
+        for regex, secondsUnit in timeOutFormatRegexList.items():
+            matchingTimes = re.findall(regex, timeOut)
+            for matchTime in matchingTimes:
+                seconds += int(matchTime[:-1]) * secondsUnit
+
+        return seconds
+
+    def _summary(self):
+        pass

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -1,0 +1,283 @@
+# **************************************************************************
+# *
+# * Authors: Daniel Marchan (da.marchan@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+import os
+from datetime import datetime
+import time
+import copy
+import numpy as np
+import random
+from collections import defaultdict
+
+from pyworkflow import VERSION_3_0
+from pwem.objects import SetOfImages, Set
+import pyworkflow.protocol.params as params
+import pyworkflow.utils as pwutils
+
+from pwem.protocols import EMProtocol
+from pyworkflow import UPDATED, NEW
+from pyworkflow.protocol.constants import STATUS_NEW, STEPS_PARALLEL
+
+
+
+OUTPUT = "outputSet"
+
+class ProtDataSampler(EMProtocol):
+    """
+    Protocol to make a subset of images from the original one.
+    Waits until certain batch of images is prepared and then it samples a percentage of it and send them to output
+    The protocol will accept Micrographs, Particles, ..., and any kind of object that inherits from Image base class.
+    """
+    _label = 'data sampler'
+    _devStatus = NEW
+    _lastUpdateVersion = VERSION_3_0
+    _possibleOutputs = {OUTPUT: SetOfImages}
+
+
+    def __init__(self, **args):
+        EMProtocol.__init__(self, **args)
+
+    def _defineParams(self, form):
+        form.addSection(label='Input')
+        form.addParam('inputImages', params.PointerParam, pointerClass='SetOfImages',
+                      label="Input images", important=True)
+        form.addParam('batchSize', params.IntParam, default=10000,
+                      label='Batch size',
+                      help='How many images need to be on input to '
+                           'make the random sampling.')
+        form.addParam('samplingProportion', params.FloatParam, default=0.25,
+                      label='Sampling proportion',
+                      help='What proportion of images need to be output from '
+                           'the random sampling.')
+        form.addSection(label='Stream of data timer')
+        form.addParam('delay', params.IntParam, default=10, label="Delay (sec)",
+                      validators=[params.GT(2, "must be larger than 3sec.")],
+                      help="Delay in seconds before checking new output")
+
+
+# --------------------------- INSERT steps functions -------------------------
+    def _insertAllSteps(self):
+        self.initializeParams()
+        self._insertFunctionStep(self.createOutputStep,
+                                 prerequisites=[], wait=True, needsGPU=False)
+
+    def createOutputStep(self):
+        self._closeOutputSet()
+
+    def initializeParams(self):
+        self.finished = False
+        # Important to have both:
+        self.insertedIds = []   # Contains images that have been inserted in a Step (checkNewInput).
+        self.processedIds = [] # Ids to be register to output
+        self.sampleIds = [] # Ids to be output
+        self.isStreamClosed = self.inputImages.get().isStreamClosed()
+        # Contains images that have been processed in a Step (checkNewOutput).
+        self.inputFn = self.inputImages.get().getFileName()
+        self._inputClass = self.inputImages.get().getClass()
+        self._inputType = self.inputImages.get().getClassName().split('SetOf')[1]
+        self._baseName = '%s.sqlite' % self._inputType.lower()
+
+    def _getFirstJoinStepName(self):
+        # This function will be used for streaming, to check which is
+        # the first function that need to wait for all ctfs
+        # to have completed, this can be overriden in subclasses
+        # (e.g., in Xmipp 'sortPSDStep')
+        return 'createOutputStep'
+
+    def _getFirstJoinStep(self):
+        for s in self._steps:
+            if s.funcName == self._getFirstJoinStepName():
+                return s
+        return None
+
+    def _stepsCheck(self):
+        self._checkNewInput()
+        self._checkNewOutput()
+
+    def _checkNewInput(self):
+        # Check if there are new ctf to process from the input set
+        self.lastCheck = getattr(self, 'lastCheck', datetime.now())
+        mTime = datetime.fromtimestamp(os.path.getmtime(self.inputFn))
+        self.debug('Last check: %s, modification: %s'
+                    % (pwutils.prettyTime(self.lastCheck),
+                        pwutils.prettyTime(mTime)))
+        # If the input movies.sqlite have not changed since our last check,
+        # it does not make sense to check for new input data
+        if self.lastCheck > mTime and self.insertedIds:  # If this is empty it is dut to a static "continue" action or it is the first round
+            return None
+
+        inputSet = self._loadInputSet(self.inputFn)
+        inputSetIds = inputSet.getIdSet()
+        newIds = [idImage for idImage in inputSetIds if idImage not in self.insertedIds]
+
+        self.lastCheck = datetime.now()
+        self.isStreamClosed = inputSet.isStreamClosed()
+        inputSet.close()
+
+        outputStep = self._getFirstJoinStep()
+
+        if self.isContinued() and not self.insertedIds:  # For "Continue" action and the first round
+            doneIds, _ = self._getAllDoneIds()
+            skipIds = list(set(newIds).intersection(set(doneIds)))
+            newIds = list(set(newIds).difference(set(doneIds)))
+            self.info("Skipping Images with ID: %s, seems to be done" % skipIds)
+            self.insertedIds = doneIds  # During the first round of "Continue" action it has to be filled
+
+        # Now handle the steps depending on the streaming batch size
+        batchSize = self.batchSize.get()
+        if len(newIds) < batchSize and not self.isStreamClosed:
+            return  # No register any step if the batch size is not reach unless is the lass iter
+
+        if newIds:
+            fDeps = self._insertNewImageSteps(newIds, batchSize)
+            if outputStep is not None:
+                outputStep.addPrerequisites(*fDeps)
+            self.updateSteps()
+
+    def _checkNewOutput(self):
+        doneListIds, currentOutputSize = self._getAllDoneIds()
+        #processedIds = copy.deepcopy(self.processedIds)
+        sampleIds = copy.deepcopy(self.sampleIds)
+        newDone = [imageId for imageId in sampleIds if imageId not in doneListIds]
+        allDone = len(doneListIds) + len(newDone)
+        maxSize = int(self._loadInputSet(self.inputFn).getSize() * self.samplingProportion.get())
+
+        # We have finished when there is not more input images
+        # (stream closed) or when the limit of output size is met
+        self.finished = self.isStreamClosed and allDone == maxSize
+        streamMode = Set.STREAM_CLOSED if self.finished else Set.STREAM_OPEN
+
+        if not self.finished and not newDone:
+            # If we are not finished and no new output have been produced
+            # it does not make sense to proceed and updated the outputs
+            # so we exit from the function here
+            return
+
+        inputSet = self._loadInputSet(self.inputFn)
+        outputSet = self._loadOutputSet(self._inputClass, self._baseName)
+
+        for imageId in newDone:
+            image = inputSet.getItem("id", imageId).clone()
+            outputSet.append(image)
+
+        self._updateOutputSet(OUTPUT, outputSet, streamMode)
+
+        if self.finished:  # Unlock createOutputStep if finished all jobs
+            outputStep = self._getFirstJoinStep()
+            if outputStep and outputStep.isWaiting():
+                outputStep.setStatus(STATUS_NEW)
+
+        self._store()
+
+    def _loadInputSet(self, inputFn):
+        self.debug("Loading input db: %s" % inputFn)
+        inputSet = self._inputClass(filename=inputFn)
+        inputSet.loadAllProperties()
+        return inputSet
+
+    def _loadOutputSet(self, SetClass, baseName):
+        setFile = self._getPath(baseName)
+
+        if os.path.exists(setFile):
+            outputSet = SetClass(filename=setFile)
+            outputSet.loadAllProperties()
+            outputSet.enableAppend()
+        else:
+            outputSet = SetClass(filename=setFile)
+            outputSet.setStreamState(outputSet.STREAM_OPEN)
+
+        inputs = self.inputImages.get()
+        outputSet.copyInfo(inputs)
+
+        return outputSet
+
+    def _insertNewImageSteps(self, newIds, batchSize):
+        """ Insert steps to register new images (from streaming)
+        Params:
+            newIds: input images ids to be processed
+        """
+        deps = []
+        # Loop through the image IDs in batches
+        for i in range(0, len(newIds), batchSize):
+            batchIds = newIds[i:i + batchSize]
+            if len(batchIds) == batchSize or self.isStreamClosed:
+                stepId = self._insertFunctionStep(self.samplingStep, batchIds, needsGPU=False,
+                                              prerequisites=[])
+                self.insertedIds.extend(batchIds)
+                deps.append(stepId)
+
+        return deps
+
+    def samplingStep(self, newIds):
+        proportion = self.samplingProportion.get()
+        sampledIds = sample_proportion(newIds, proportion)
+        self.processedIds.extend(newIds)
+        self.sampleIds.extend(sampledIds)
+
+        self.info('From %d new images, %d were random sampled with a proportion of %2f.'
+                  %(len(newIds), len(sampledIds), proportion))
+
+        if not self.isStreamClosed:
+            self.delayRegister()
+
+    def delayRegister(self):
+        delay = self.delay.get()
+        self.info('Sleeping for delay time: %d' %delay)
+        time.sleep(delay)
+
+    # ------------------------- UTILS functions --------------------------------
+    def _getAllDoneIds(self):
+        doneIds = []
+        sizeOutput = 0
+
+        if hasattr(self, OUTPUT):
+            sizeOutput = self.outputSet.getSize()
+            doneIds.extend(list(self.outputSet.getIdSet()))
+
+        return doneIds, sizeOutput
+
+
+    def _summary(self):
+        pass
+
+
+def sample_proportion(ids_list, proportion=0.25):
+    """
+    Randomly sample a proportion of elements from a list.
+
+    Parameters:
+    - ids_list (list): The list of elements to sample from.
+    - proportion (float): The proportion of the list to sample (e.g., 0.25 for 25%).
+
+    Returns:
+    - list: A new list containing the sampled elements.
+    """
+    # Calculate the number of elements to sample
+    sample_size = int(len(ids_list) * proportion)
+
+    # Randomly sample elements without replacement
+    sampled_list = random.sample(ids_list, sample_size)
+
+    return sampled_list

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -27,9 +27,7 @@ import os
 from datetime import datetime
 import time
 import copy
-import numpy as np
 import random
-from collections import defaultdict
 
 from pyworkflow import VERSION_3_0
 from pwem.objects import SetOfImages, Set
@@ -38,7 +36,7 @@ import pyworkflow.utils as pwutils
 
 from pwem.protocols import EMProtocol
 from pyworkflow import UPDATED, NEW
-from pyworkflow.protocol.constants import STATUS_NEW, STEPS_PARALLEL
+from pyworkflow.protocol.constants import STATUS_NEW
 
 
 
@@ -70,7 +68,7 @@ class ProtDataSampler(EMProtocol):
         form.addParam('samplingProportion', params.FloatParam, default=0.25,
                       label='Sampling proportion',
                       help='What proportion of images need to be output from '
-                           'the random sampling.')
+                           'the random sampling (1 means all images and 0 means none).')
         form.addSection(label='Stream of data timer')
         form.addParam('delay', params.IntParam, default=10, label="Delay (sec)",
                       validators=[params.GT(2, "must be larger than 3sec.")],

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -117,13 +117,13 @@ class ProtDataSampler(EMProtocol):
         self._checkNewOutput()
 
     def _checkNewInput(self):
-        # Check if there are new ctf to process from the input set
+        # Check if there are new images to process from the input set
         self.lastCheck = getattr(self, 'lastCheck', datetime.now())
         mTime = datetime.fromtimestamp(os.path.getmtime(self.inputFn))
         self.debug('Last check: %s, modification: %s'
                     % (pwutils.prettyTime(self.lastCheck),
                         pwutils.prettyTime(mTime)))
-        # If the input movies.sqlite have not changed since our last check,
+        # If the input.sqlite have not changed since our last check,
         # it does not make sense to check for new input data
         if self.lastCheck > mTime and self.insertedIds:  # If this is empty it is dut to a static "continue" action or it is the first round
             return None
@@ -257,7 +257,6 @@ class ProtDataSampler(EMProtocol):
             doneIds.extend(list(self.outputSet.getIdSet()))
 
         return doneIds, sizeOutput
-
 
     def _summary(self):
         pass

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -47,7 +47,7 @@ OUTPUT = "outputSet"
 class ProtDataSampler(EMProtocol):
     """
     Protocol to make a subset of images from the original one.
-    Waits until certain batch of images is prepared and then it samples a percentage of it and send them to output
+    Waits until certain batch of images is prepared, then it samples a percentage of it and send them to output.
     The protocol will accept Micrographs, Particles, ..., and any kind of object that inherits from Image base class.
     """
     _label = 'data sampler'

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -158,7 +158,6 @@ class ProtDataSampler(EMProtocol):
 
     def _checkNewOutput(self):
         doneListIds, currentOutputSize = self._getAllDoneIds()
-        #processedIds = copy.deepcopy(self.processedIds)
         sampleIds = copy.deepcopy(self.sampleIds)
         newDone = [imageId for imageId in sampleIds if imageId not in doneListIds]
         allDone = len(doneListIds) + len(newDone)

--- a/emfacilities/protocols/protocol_good_classes_extractor.py
+++ b/emfacilities/protocols/protocol_good_classes_extractor.py
@@ -112,6 +112,7 @@ class ProtGoodClassesExtractor(EMProtocol, ProtStreamingBase):
                                                        prerequisites=selectStep)
 
                 self.newDeps.append(extractStep)
+                classSet.close()
 
             if self.isStreamClosed == Set.STREAM_CLOSED:
                 self.info('Stream closed')

--- a/emfacilities/protocols/protocol_monitor_2d_streamer.py
+++ b/emfacilities/protocols/protocol_monitor_2d_streamer.py
@@ -69,7 +69,7 @@ class ProtMonitor2dStreamer(ProtMonitor):
                            'many 2D classification runs based on the 2D '
                            'protocol template selected. ')
 
-        form.addParam('batchSize', params.IntParam,
+        form.addParam('batchSize', params.IntParam,  default=25000,
                       label="Batch size",
                       help="How many particles (approximately) you want to "
                            "group to make the new batch and launch a new 2d"

--- a/emfacilities/tests/protocols/test_protocol_data_counter.py
+++ b/emfacilities/tests/protocols/test_protocol_data_counter.py
@@ -23,11 +23,11 @@
 from pyworkflow.tests import BaseTest, setupTestProject, DataSet
 from pwem.protocols.protocol_import import ProtImportParticles
 from pyworkflow.object import Pointer
-from emfacilities.protocols.protocol_data_sampler import ProtDataSampler
+from emfacilities.protocols.protocol_data_counter import ProtDataCounter
 
 
-class TestDataSampler(BaseTest):
-    """ Test data sampler protocol """
+class TestDataCounter(BaseTest):
+    """ Test data counter protocol """
 
     @classmethod
     def setData(cls):
@@ -56,18 +56,17 @@ class TestDataSampler(BaseTest):
 
         cls.launchProtocol(cls.protImport)
 
-    def testDataSampler25(self):
-        prot = self._runDataSampler("Random sampling of 0.25 proportion", batch=1000, proportion=0.25)
-        self.assertSetSize(prot.outputSet, size=1175)
+    def testDataCounter2000(self):
+        prot = self._runDataCounter("Counter images till 2000", outputSize=2000)
+        self.assertSetSize(prot.outputSet, size=2000)
 
-    def testDataSampler50(self):
-        prot = self._runDataSampler("Random sampling of 0.5 proportion", batch=1000,  proportion=0.5)
-        self.assertSetSize(prot.outputSet, size=2350)
+    def testDataCounter4000(self):
+        prot = self._runDataCounter("Counter images till 4000", outputSize=4000)
+        self.assertSetSize(prot.outputSet, size=4000)
 
-    def _runDataSampler(cls, label, batch, proportion):
-        protDataSampler = cls.newProtocol(ProtDataSampler,
-                                          batchSize=batch,
-                                          samplingProportion=proportion,
+    def _runDataCounter(cls, label, outputSize):
+        protDataSampler = cls.newProtocol(ProtDataCounter,
+                                          outputSize=outputSize,
                                           delay=3)
         protDataSampler.inputImages = Pointer(cls.protImport, extended='outputParticles')
         protDataSampler.setObjLabel(label)

--- a/emfacilities/tests/protocols/test_protocol_data_sampler.py
+++ b/emfacilities/tests/protocols/test_protocol_data_sampler.py
@@ -1,0 +1,76 @@
+# ***************************************************************************
+# * Authors:    Daniel Marchán (da.marchan@cnb.csic.es)
+# *
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 3 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# ***************************************************************************/
+from pyworkflow.tests import BaseTest, setupTestProject, DataSet
+from pwem.protocols.protocol_import import ProtImportParticles
+from pyworkflow.object import Pointer
+from emfacilities.protocols.protocol_data_sampler import ProtDataSampler
+
+
+class TestDataSampler(BaseTest):
+    """ Test good classes extractor protocol """
+
+    @classmethod
+    def setData(cls):
+        cls.dsRelion = DataSet.getDataSet('relion_tutorial')
+
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.setData()
+        # Run needed protocols
+        cls.runImportParticles()
+
+    @classmethod
+    def runImportParticles(cls):
+        """
+        Import an EMX file with Particles and defocus
+        """
+        cls.protImport = cls.newProtocol(ProtImportParticles,
+                                         objLabel='from relion (classify 2d)',
+                                         importFrom=ProtImportParticles.IMPORT_FROM_RELION,
+                                         starFile=cls.dsRelion.getFile('import/classify2d/extra/relion_it015_data.star'),
+                                         magnification=10000,
+                                         samplingRate=7.08,
+                                         haveDataBeenPhaseFlipped=True
+                                         )
+
+        cls.launchProtocol(cls.protImport)
+
+    def testDataSampler25(self):
+        prot = self._runDataSampler("Random sampling of 0.25 proportion", batch=1000, proportion=0.25)
+        self.assertSetSize(prot.outputSet, size=1175)
+
+    def testDataSampler50(self):
+        prot = self._runDataSampler("Random sampling of 0.5 proportion", batch=1000,  proportion=0.5)
+        self.assertSetSize(prot.outputSet, size=2350)
+
+    def _runDataSampler(cls, label, batch, proportion):
+        protDataSampler = cls.newProtocol(ProtDataSampler,
+                                          batchSize=batch,
+                                          samplingProportion=proportion,
+                                          delay=3)
+        protDataSampler.inputImages = Pointer(cls.protImport, extended='outputParticles')
+        protDataSampler.setObjLabel(label)
+        cls.launchProtocol(protDataSampler)
+
+        return protDataSampler


### PR DESCRIPTION
These two protocols run in streaming mode and are generic protocols that works with Images (Movies, Mics, Particles, etc):
- Data counter is a protocol to count input images until a certain number is achieved. Then it will close the output set with these images. This protocol has the option to set a timer, again if the timer is consumed it will close the output set with the corresponding images at this moment. 
- Data sampler is a protocol that randomly samples a proportion of your images. It works on batches and in every batch it will stay with the proportion you set. Very useful when you dont want to process all your data. 