### PR TITLE
Oscem minor updates

### DIFF
--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -693,7 +693,7 @@ class ProtOSCEM(EMProtocol):
             collage_filepath = join(output_folder, collage_filename)
             self.create_collage(images, collage_filepath)
 
-        classes_2D = {"number_classes_2D": classes, "particles_per_2Dclass": particles_list,
+        classes_2D = {"particles_per_2Dclass": particles_list,
                       "images_classes_2D": collage_filename}
 
         return classes_2D
@@ -963,7 +963,7 @@ class ProtOSCEM(EMProtocol):
         collage_filepath = join(classes3D_folder_path, collage_filename)
         self.create_collage(images, collage_filepath)
 
-        classes_3D = {"number_classes_3D": classes, "particles_per_3Dclass": particles_list,
+        classes_3D = {"particles_per_3Dclass": particles_list,
                       "images_classes_3D": join(classes_3D_folder_name, collage_filename),
                       "volumes": volumes_list}
         return classes_3D

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -700,6 +700,7 @@ class ProtOSCEM(EMProtocol):
 
     def volume_generation(self, volume_type, folder_name, volume, th):
         vol_size = str(volume.getDim())
+        vol_size_list = [int(x) for x in vol_size.strip('()').split(',')]
         if volume_type == 'final volume':
             half_maps = volume.getHalfMaps()
             half_maps1, half_maps2 = half_maps.split(',')
@@ -779,7 +780,7 @@ class ProtOSCEM(EMProtocol):
                     'value': resolution,
                     'unit': 'Å',
                     },
-                'size': vol_size,
+                'size': vol_size_list,
                 'orthogonal_slices': {
                     'orthogonal_slices_X': join(folder_name, orthogonal_slices_folder, slices_x),
                     'orthogonal_slices_Y': join(folder_name, orthogonal_slices_folder, slices_y),
@@ -798,7 +799,7 @@ class ProtOSCEM(EMProtocol):
             volume = {
                 'volume_type': volume_type,
                 'vol_number_particles': size,
-                'size': vol_size,
+                'size': vol_size_list,
                 'orthogonal_slices': {
                     'orthogonal_slices_X': join(folder_name, orthogonal_slices_folder, slices_x),
                     'orthogonal_slices_Y': join(folder_name, orthogonal_slices_folder, slices_y),
@@ -816,7 +817,7 @@ class ProtOSCEM(EMProtocol):
                     'value': resolution,
                     'unit': 'Å',
                     },
-                'size': vol_size,
+                'size': vol_size_list,
                 'orthogonal_slices': {
                     'orthogonal_slices_X': join(folder_name, orthogonal_slices_folder, slices_x),
                     'orthogonal_slices_Y': join(folder_name, orthogonal_slices_folder, slices_y),
@@ -830,7 +831,7 @@ class ProtOSCEM(EMProtocol):
         else:
             volume = {
                 'volume_type': volume_type,
-                'size': vol_size,
+                'size': vol_size_list,
                 'orthogonal_slices': {
                     'orthogonal_slices_X': join(folder_name, orthogonal_slices_folder, slices_x),
                     'orthogonal_slices_Y': join(folder_name, orthogonal_slices_folder, slices_y),

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -179,7 +179,7 @@ class TestOscemMetadata(BaseTest):
             "volumes": [
                 {
                     "volume_type": "initial volume",
-                    "size": "(250, 250, 250)",
+                    "size": [250, 250, 250],
                     "orthogonal_slices": {
                         "orthogonal_slices_X": "Initial_volume/orthogonal_slices/orthogonal_slices_X.jpg",
                         "orthogonal_slices_Y": "Initial_volume/orthogonal_slices/orthogonal_slices_Y.jpg",
@@ -198,7 +198,7 @@ class TestOscemMetadata(BaseTest):
                         "value": 3.39,
                         "unit": "Å"
                     },
-                    "size": "(250, 250, 250)",
+                    "size": [250, 250, 250],
                     "orthogonal_slices": {
                         "orthogonal_slices_X": "Final_volume/orthogonal_slices/orthogonal_slices_X.jpg",
                         "orthogonal_slices_Y": "Final_volume/orthogonal_slices/orthogonal_slices_Y.jpg",
@@ -212,7 +212,7 @@ class TestOscemMetadata(BaseTest):
                 },
                 {
                     "volume_type": "sharpened volume",
-                    "size": "(250, 250, 250)",
+                    "size": [250, 250, 250],
                     "orthogonal_slices": {
                         "orthogonal_slices_X": "Sharpened_volume/orthogonal_slices/orthogonal_slices_X.jpg",
                         "orthogonal_slices_Y": "Sharpened_volume/orthogonal_slices/orthogonal_slices_Y.jpg",

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -132,7 +132,6 @@ class TestOscemMetadata(BaseTest):
                 "micrograph_examples": "Micro_examples/micro_particles.jpg"
             },
             "classes2D": {
-                "number_classes_2D": 20,
                 "particles_per_2Dclass": [
                     333,
                     296,
@@ -158,7 +157,6 @@ class TestOscemMetadata(BaseTest):
                 "images_classes_2D": "classes_2D.jpg"
             },
             "classes3D": {
-                "number_classes_3D": 1,
                 "particles_per_3Dclass": [
                     2937
                 ],
@@ -622,12 +620,7 @@ class TestOscemMetadata(BaseTest):
             Compares rest of key-values (test_data and current_data) and raises assertion errors if there are mismatches.
             """
         key_in = parent_key.split('.')[-1]
-        if (
-                key_in == "number_micrographs"
-                or key_in == "discarded_movies"
-                or key_in == "number_classes_2D"
-                or key_in == "number_classes_3D"
-        ):
+        if key_in == "number_micrographs" or key_in == "discarded_movies":
             self.assertAlmostEqual(
                 test_data, current_data, delta=2,
                 msg=f"Value mismatch at {parent_key}: {test_data} != {current_data}"


### PR DESCRIPTION
Updates related to slots in the oscem metadata schema. Deleted the 'number_classes' slot in 2D and 3D classes and updated the volume size slot to a list instead of string.