### PR TITLE
Optimized protocols: data counter and data sampler

### DIFF
--- a/emfacilities/protocols/protocol_data_counter.py
+++ b/emfacilities/protocols/protocol_data_counter.py
@@ -99,8 +99,8 @@ class ProtDataCounter(EMProtocol):
     def initializeParams(self):
         self.finished = False
         # Important to have both:
-        self.insertedIds = []   # Contains images that have been inserted in a Step (checkNewInput).
-        self.processedIds = [] # Ids to be output
+        self.insertedIds = set() # Contains images that have been inserted in a Step (checkNewInput).
+        self.processedIds = set() # Ids to be output
         self.isStreamClosed = self.inputImages.get().isStreamClosed()
         # Contains images that have been processed in a Step (checkNewOutput).
         self.inputFn = self.inputImages.get().getFileName()
@@ -148,7 +148,7 @@ class ProtDataCounter(EMProtocol):
         if self.lastRound:
             self.info("Last round sleeping for 10 seconds to allow all the input to be loaded")
             time.sleep(10) # Needs to make sure that eventhough the stream is closed all the data in the inputset is loaded
-        
+
         inputSet = self._loadInputSet(self.inputFn)
         inputSetIds = inputSet.getIdSet()
         newIds = [idImage for idImage in inputSetIds if idImage not in self.insertedIds]
@@ -166,7 +166,7 @@ class ProtDataCounter(EMProtocol):
             skipIds = list(set(newIds).intersection(set(doneIds)))
             newIds = list(set(newIds).difference(set(doneIds)))
             self.info("Skipping Images with ID: %s, seems to be done" % skipIds)
-            self.insertedIds = doneIds  # During the first round of "Continue" action it has to be filled
+            self.insertedIds = set(doneIds) # During the first round of "Continue" action it has to be filled
 
         if newIds and not self.limitReach and not self.timerOut:
             fDeps = self._insertNewImageSteps(newIds)
@@ -179,8 +179,9 @@ class ProtDataCounter(EMProtocol):
             return
 
         doneListIds, currentOutputSize = self._getAllDoneIds()
-        processedIds = copy.deepcopy(self.processedIds)
-        newDone = [imageId for imageId in processedIds if imageId not in doneListIds]
+        # Make doneListIds a set for fast lookups
+        doneSet = set(doneListIds)
+        newDone = self.processedIds - doneSet
         allDone = len(doneListIds) + len(newDone)
         limitOutputSize = self.outputSize.get()
         maxSize = self._loadInputSet(self.inputFn).getSize()
@@ -250,14 +251,13 @@ class ProtDataCounter(EMProtocol):
         stepId = self._insertFunctionStep(self.registerStep, newIds, needsGPU=False,
                                           prerequisites=[])
         deps.append(stepId)
-        self.insertedIds.extend(newIds)
+        self.insertedIds.update(newIds)
 
         return deps
 
     def registerStep(self, newIds):
         self.info('Registering the %d new images' %len(newIds))
-        for imageId in newIds:
-            self.processedIds.append(imageId)
+        self.processedIds.update(newIds)
 
         if not self.isStreamClosed:
             if self.boolTimer.get():

--- a/emfacilities/protocols/protocol_data_sampler.py
+++ b/emfacilities/protocols/protocol_data_sampler.py
@@ -82,9 +82,9 @@ class ProtDataSampler(EMProtocol):
     def initializeParams(self):
         self.finished = False
         # Important to have both:
-        self.insertedIds = []   # Contains images that have been inserted in a Step (checkNewInput).
-        self.processedIds = [] # Ids to be register to output
-        self.sampleIds = [] # Ids to be output
+        self.insertedIds = set()   # Contains images that have been inserted in a Step (checkNewInput).
+        self.processedIds = set() # Ids to be register to output
+        self.sampleIds = set() # Ids to be output
         self.isStreamClosed = self.inputImages.get().isStreamClosed()
         # Contains images that have been processed in a Step (checkNewOutput).
         self.inputFn = self.inputImages.get().getFileName()
@@ -133,10 +133,12 @@ class ProtDataSampler(EMProtocol):
 
         if self.isContinued() and not self.insertedIds:  # For "Continue" action and the first round
             doneIds, _ = self._getAllDoneIds()
-            skipIds = list(set(newIds).intersection(set(doneIds)))
-            newIds = list(set(newIds).difference(set(doneIds)))
+            doneIdsSet = set(doneIds)
+            newIdsSet = set(newIds)
+            skipIds = list(newIdsSet & doneIdsSet)
+            newIds = list(newIdsSet - doneIdsSet)
             self.info("Skipping Images with ID: %s, seems to be done" % skipIds)
-            self.insertedIds = doneIds  # During the first round of "Continue" action it has to be filled
+            self.insertedIds = set(doneIds)  # During the first round of "Continue" action it has to be filled
 
         # Now handle the steps depending on the streaming batch size
         batchSize = self.batchSize.get()
@@ -151,8 +153,8 @@ class ProtDataSampler(EMProtocol):
 
     def _checkNewOutput(self):
         doneListIds, currentOutputSize = self._getAllDoneIds()
-        sampleIds = copy.deepcopy(self.sampleIds)
-        newDone = [imageId for imageId in sampleIds if imageId not in doneListIds]
+        doneIdSet = set(doneListIds)
+        newDone = list(self.sampleIds - doneIdSet)
         allDone = len(doneListIds) + len(newDone)
         maxSize = int(self._loadInputSet(self.inputFn).getSize() * self.samplingProportion.get())
 
@@ -217,7 +219,7 @@ class ProtDataSampler(EMProtocol):
             if len(batchIds) == batchSize or self.isStreamClosed:
                 stepId = self._insertFunctionStep(self.samplingStep, batchIds, needsGPU=False,
                                               prerequisites=[])
-                self.insertedIds.extend(batchIds)
+                self.insertedIds.update(batchIds)
                 deps.append(stepId)
 
         return deps
@@ -225,8 +227,8 @@ class ProtDataSampler(EMProtocol):
     def samplingStep(self, newIds):
         proportion = self.samplingProportion.get()
         sampledIds = sample_proportion(newIds, proportion)
-        self.processedIds.extend(newIds)
-        self.sampleIds.extend(sampledIds)
+        self.processedIds.update(newIds)
+        self.sampleIds.update(sampledIds)
 
         self.info('From %d new images, %d were random sampled with a proportion of %.2f'
                   %(len(newIds), len(sampledIds), proportion))


### PR DESCRIPTION
 These protocols werent thought to work at particles levels. However as this is a generic protocol that works with Images and we have seen that they are very useful for particles we have adapted to deal better with large amounts of images. Tested on more than 500k where the previous version was having problems with the streaming and list operations. 

Main enhancements replace list operations by set operations which is considerably more efficient and faster, now the protocols do not show any delay.