### PR TITLE
Fixing the test for OSCEM protocol

### DIFF
--- a/emfacilities/__init__.py
+++ b/emfacilities/__init__.py
@@ -37,8 +37,6 @@ _references = ["delaRosaTrevin201693"]
 _url = URL
 
 class Plugin(pwem.Plugin):
-    _homeVar = EMFACILITIES_HOME_VARNAME 
-    _pathVars = [EMFACILITIES_HOME_VARNAME]
 
     @classmethod
     def _defineVariables(cls):

--- a/emfacilities/__init__.py
+++ b/emfacilities/__init__.py
@@ -32,6 +32,7 @@ import pwem
 
 from .constants import *
 
+__version__ = "3.3.0"
 _logo = "facilityLogo.png"
 _references = ["delaRosaTrevin201693"]
 _url = URL
@@ -77,7 +78,7 @@ class Plugin(pwem.Plugin):
         installEnvVars = {'PATH': envPath} if envPath else None
 
         env.addPackage(FACLITIES_STREAMLIT,
-                       version=FACILITIES_VERSION,
+                       version=__version__,
                        tar='void.tgz',
                        commands=STRM_commands,
                        neededProgs=[],

--- a/emfacilities/constants.py
+++ b/emfacilities/constants.py
@@ -31,11 +31,11 @@ This modules contains constants related to emfacilities
 URL = 'https://scipion-em.github.io/docs/docs/facilities/facilities.html'
 SECRETSFILE = 'secrets.cfg'
 EMFACILITIES_HOME_VARNAME = 'EMFACILITIES_HOME'
-FACILITIES_VERSION = '3.3.0'
+FACILITIES_VERSION_FOR_VIEWER = '3.3.0'
 
 # Streamlit environment
 FACLITIES_STREAMLIT = 'facilities-streamlit'
-STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-{FACILITIES_VERSION}'
+STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-{FACILITIES_VERSION_FOR_VIEWER}'
 STRM_PROGRAM = 'streamlit'
 
 FACILITIES_ENV_ACTIVATION = 'FACILITIES_ENV_ACTIVATION'

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -919,6 +919,10 @@ class ProtOSCEM(EMProtocol):
                 ########## VOLUMES ##########
                 #############################
 
+                # Volume size
+                size = data.shape
+                vol_size_list = [int(x) for x in size]
+
                 # Getting orthogonal slices in X, Y and Z
                 # Folder to store orthogonal slices
                 orthogonal_slices_folder = f'orthogonal_slices_volume{i + 1}'
@@ -943,6 +947,7 @@ class ProtOSCEM(EMProtocol):
 
                 # Dictionary fill in:
                 volume = {
+                    "size": vol_size_list,
                     "orthogonal_slices": {
                         "orthogonal_slices_X": join(classes_3D_folder_name, orthogonal_slices_folder,
                                                     slices_x),

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -163,6 +163,7 @@ class TestOscemMetadata(BaseTest):
                 "images_classes_3D": "Classes_3D/classes_3D.jpg",
                 "volumes": [
                     {
+                        "size": [250, 250, 250],
                         "orthogonal_slices": {
                             "orthogonal_slices_X": "Classes_3D/orthogonal_slices_volume1/orthogonal_slices_X.jpg",
                             "orthogonal_slices_Y": "Classes_3D/orthogonal_slices_volume1/orthogonal_slices_Y.jpg",

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -27,7 +27,7 @@ class TestOscemMetadata(BaseTest):
     """
     """
     sampling_rate = 0.495
-    max_movie_shift = 20.0
+    max_movie_shift = 60
     ctf_down_factor = 2.0
     high_res = 0.5
     test_data = {
@@ -282,7 +282,9 @@ class TestOscemMetadata(BaseTest):
     @classmethod
     def runMovieGain(cls):
         prot = cls.newProtocol(XmippProtMovieGain,
-                               inputMovies=cls.importedmovies)
+                               inputMovies=cls.importedmovies,
+                               estimateGain=False,
+                               estimateResidualGain=False)
 
         cls.launchProtocol(prot)
         output = getattr(prot, 'outputMovies', None)
@@ -393,7 +395,9 @@ class TestOscemMetadata(BaseTest):
         prot = cls.newProtocol(ProtCryoSparcNewNonUniformRefine3D,
                                inputParticles=cls.particles,
                                referenceVolume=cls.imported_volume_classes3D,
-                               symmetryGroup=SYM_TETRAHEDRAL)
+                               symmetryGroup=SYM_TETRAHEDRAL,
+                               refine_defocus_refine=False,
+                               refine_ctf_global_refine=False)
 
         cls.launchProtocol(prot)
         output1 = getattr(prot, 'outputVolume', None)

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -63,7 +63,7 @@ class TestOscemMetadata(BaseTest):
                 {
                     "descriptor_name": "XmippProtMovieMaxShift",
                     "descriptor_thing":
-                        {"discarded_movies": 9,
+                        {"discarded_movies": 2,
                          "max_frame_shift": {
                              "value": 5.0,
                              "unit": "Å"

--- a/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
+++ b/emfacilities/tests/protocols/test_protocol_OSCEM_metadata.py
@@ -52,7 +52,7 @@ class TestOscemMetadata(BaseTest):
                              "frameN": 30
                          },
                          "output_avg_shift": {
-                             "value": 11.8,
+                             "value": 11.0,
                              "unit": "Å"
                          },
                          "output_max_shift": {
@@ -65,20 +65,20 @@ class TestOscemMetadata(BaseTest):
                     "descriptor_thing":
                         {"discarded_movies": 2,
                          "max_frame_shift": {
-                             "value": 5.0,
+                             "value": 10.0,
                              "unit": "Å"
                          },
                          "max_movie_shift": {
-                             "value": 20.0,
+                             "value": 60.0,
                              "unit": "Å"
                          },
                          "rejection_type": "by frame or movie",
                          "output_avg_shift": {
-                             "value": 11.8,
+                             "value": 11.4,
                              "unit": "Å"
                          },
                          "output_max_shift": {
-                             "value": 29.7,
+                             "value": 34.6,
                              "unit": "Å"
                          },
                          "shift_histogram": "shift_hist.jpg"}
@@ -86,21 +86,21 @@ class TestOscemMetadata(BaseTest):
             ]
         },
             "micrographs": {
-                "number_micrographs": 21
+                "number_micrographs": 28
             },
             "CTFs": {
                 "amplitude_contrast": 0.1,
                 "defocus": {
                     "output_min_defocus": {
-                        "value": 4199.7,
+                        "value": 4794.4,
                         "unit": "Å"
                     },
                     "output_max_defocus": {
-                        "value": 11828.1,
+                        "value": 12373.8,
                         "unit": "Å"
                     },
                     "output_avg_defocus": {
-                        "value": 9424.5,
+                        "value": 9803.1,
                         "unit": "Å"
                     },
                     "defocus_histogram": "defocus_hist.jpg",
@@ -108,11 +108,11 @@ class TestOscemMetadata(BaseTest):
                 },
                 "resolution": {
                     "output_min_resolution": {
-                        "value": 3.9,
+                        "value": 3.4,
                         "unit": "Å"
                     },
                     "output_max_resolution": {
-                        "value": 2.8,
+                        "value": 2.9,
                         "unit": "Å"
                     },
                     "output_avg_resolution": {
@@ -126,39 +126,39 @@ class TestOscemMetadata(BaseTest):
                 }
             },
             "coordinates": {
-                "number_particles": 2937,
-                "particles_per_micrograph": 139.9,
+                "number_particles": 3986,
+                "particles_per_micrograph": 142.4,
                 "particles_histogram": "particles_hist.jpg",
                 "micrograph_examples": "Micro_examples/micro_particles.jpg"
             },
             "classes2D": {
                 "particles_per_2Dclass": [
-                    333,
-                    296,
-                    235,
-                    231,
-                    228,
-                    212,
-                    202,
-                    192,
-                    182,
-                    168,
-                    96,
-                    91,
-                    82,
-                    80,
-                    76,
-                    65,
-                    62,
-                    59,
-                    27,
-                    20
+                    382,
+                    353,
+                    346,
+                    342,
+                    335,
+                    321,
+                    320,
+                    288,
+                    259,
+                    240,
+                    125,
+                    117,
+                    101,
+                    93,
+                    92,
+                    84,
+                    68,
+                    54,
+                    54,
+                    12,
                 ],
                 "images_classes_2D": "classes_2D.jpg"
             },
             "classes3D": {
                 "particles_per_3Dclass": [
-                    2937
+                    3986
                 ],
                 "images_classes_3D": "Classes_3D/classes_3D.jpg",
                 "volumes": [
@@ -193,9 +193,9 @@ class TestOscemMetadata(BaseTest):
                 },
                 {
                     "volume_type": "final volume",
-                    "vol_number_particles": 2937,
+                    "vol_number_particles": 3986,
                     "vol_resolution": {
-                        "value": 3.39,
+                        "value": 3.31,
                         "unit": "Å"
                     },
                     "size": [250, 250, 250],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,20 +1,10 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "scipion-em-facilities"
-dynamic = ["version"]
-dependencies = ["scipion-pyworkflow>=3.0.31",
-                "scipion-em",
-                "nvidia-ml-py3",
-                "pytz",
-                "paramiko",
-                "influxdb",
-                "joblib",
-                "networkx",
-                "scipion-em-xmipp",
-                "pyyaml"]
+dynamic = ["version", "dependencies"]
                 
 description = "Plugin to use Scipion in facilities"
 readme = "README.rst"
@@ -28,6 +18,7 @@ Issues = "https://github.com/scipion-em/scipion-em-facilities/issues"
 
 [tool.setuptools.dynamic]
 version = {attr = "emfacilities.__version__"}
+dependencies = {file = ["requirements.txt"]}
 
 [project.entry-points."pyworkflow.plugin"]
 emfacilities = "emfacilities"


### PR DESCRIPTION
In this branch I have solved the errors that appeared when launching the oscem protocol test.
- updated the __init__.py: __version__ required a direct number and could not take a defined variable (installation failed). Also eliminated _homeVar and _pathVars variables which caused a validateInstallation error.
- updated the constants.py
- updated pyproject.toml to include the requirements.txt as a dynamic variable
- updated the test data used in this the oscem protocol test to compare output values