### PR TITLE
Fixed duplication of __version__ in __init__.py

### DIFF
--- a/emfacilities/__init__.py
+++ b/emfacilities/__init__.py
@@ -32,11 +32,10 @@ import pwem
 
 from .constants import *
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 _logo = "facilityLogo.png"
 _references = ["delaRosaTrevin201693"]
 _url = URL
-__version__ = FACILITIES_VERSION
 
 class Plugin(pwem.Plugin):
 

--- a/emfacilities/constants.py
+++ b/emfacilities/constants.py
@@ -31,11 +31,10 @@ This modules contains constants related to emfacilities
 URL = 'https://scipion-em.github.io/docs/docs/facilities/facilities.html'
 SECRETSFILE = 'secrets.cfg'
 EMFACILITIES_HOME_VARNAME = 'EMFACILITIES_HOME'
-STREAMLIT_VERSION_FOR_VIEWER = '1.50.0'
 
 # Streamlit environment
 FACLITIES_STREAMLIT = 'facilities-streamlit'
-STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-{STREAMLIT_VERSION_FOR_VIEWER}'
+STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-env'
 STRM_PROGRAM = 'streamlit'
 
 FACILITIES_ENV_ACTIVATION = 'FACILITIES_ENV_ACTIVATION'

--- a/emfacilities/constants.py
+++ b/emfacilities/constants.py
@@ -31,11 +31,11 @@ This modules contains constants related to emfacilities
 URL = 'https://scipion-em.github.io/docs/docs/facilities/facilities.html'
 SECRETSFILE = 'secrets.cfg'
 EMFACILITIES_HOME_VARNAME = 'EMFACILITIES_HOME'
-FACILITIES_VERSION_FOR_VIEWER = '3.3.0'
+STREAMLIT_VERSION_FOR_VIEWER = '1.50.0'
 
 # Streamlit environment
 FACLITIES_STREAMLIT = 'facilities-streamlit'
-STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-{FACILITIES_VERSION_FOR_VIEWER}'
+STRM_ENV_NAME = f'{FACLITIES_STREAMLIT}-{STREAMLIT_VERSION_FOR_VIEWER}'
 STRM_PROGRAM = 'streamlit'
 
 FACILITIES_ENV_ACTIVATION = 'FACILITIES_ENV_ACTIVATION'


### PR DESCRIPTION
In the __init__.py we now have only once defined the __version__.
Also, in the constants.py I have change the name of the conda environment to contain the streamlit version instead of the facilities version to avoid confusion.
I have also updated the version to 3.3.1.