### PR TITLE
Updates in OSCEM protocol

### DIFF
--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -992,7 +992,7 @@ class ProtOSCEM(EMProtocol):
     def load_image_path(self, path):
         ext = os.path.splitext(path)[1].lower()
         # MRC/MRCS
-        if ext in [".mrc", ".mrcs"]:
+        if ext in [".mrc", ".mrcs", ".gain"]:
             with mrcfile.open(path, 'r') as mrc:
                 return np.array(mrc.data, dtype=np.float32)
         # TIFF/TIF

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -1017,7 +1017,6 @@ class ProtOSCEM(EMProtocol):
         descriptor_thing_dict = {}
         ################################ INPUT #############################################
         input_alignment = MovieAlignmentProt.getObjDict()
-        print(dir(MovieAlignmentProt))
         # List of keys to retrieve
         keys_to_retrieve = ['binFactor', 'maxResForCorrelation', 'gainRot', 'gainFlip']
 

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -903,8 +903,9 @@ class ProtOSCEM(EMProtocol):
             # Option 2:
             if ':' in file_name:
                 file_name_without_suffix = file_name.split(':')[0]
+                file_name = file_name_without_suffix
 
-            with mrcfile.open(file_name_without_suffix, 'r') as mrc:
+            with mrcfile.open(file_name, 'r') as mrc:
                 data = mrc.data
 
                 ############################
@@ -956,7 +957,7 @@ class ProtOSCEM(EMProtocol):
                 os.makedirs(isosurface_images_path, exist_ok=True)
 
                 th = int(self.threshold_classes3D.get())
-                volume_file_abspath = abspath(file_name_without_suffix)
+                volume_file_abspath = abspath(file_name)
                 front_view_img = 'front_view.jpg'
                 side_view_img = 'side_view.jpg'
                 top_view_img = 'top_view.jpg'

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -1124,7 +1124,8 @@ class ProtOSCEM(EMProtocol):
         """
         ###### MAX SHIFT DESCRIPTOR######
         MaxShiftProt = self.maxShift.get()
-        movie_maxshift = {'descriptor_name': MaxShiftProt.getClassName()}
+        prot_name = MaxShiftProt.getClassName()
+        movie_maxshift = {'descriptor_name': prot_name}
         descriptor_thing_dict = {}
         ############################### INPUT #############################################
         input_shift = MaxShiftProt.getObjDict()
@@ -1164,6 +1165,10 @@ class ProtOSCEM(EMProtocol):
                     attributes_dict = dict(attributes)
                     shiftX = attributes_dict.get('_xmipp_ShiftX')
                     shiftY = attributes_dict.get('_xmipp_ShiftY')
+                    if not shiftX or not shiftY:
+                        alignment = attributes_dict.get('_alignment')
+                        shiftX = getattr(alignment, "_xshifts", None)
+                        shiftY = getattr(alignment, "_yshifts", None)
                     norm = np.linalg.norm([shiftX, shiftY], axis=0)
                     shift_list.append(norm)
 

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -1092,14 +1092,12 @@ class ProtOSCEM(EMProtocol):
             max_shifts = []
             for index, item in enumerate(output.iterItems()):
                 attributes_dict = dict(item.getAttributes())
-                if prot_name == 'XmippProtFlexAlign':
-                    shiftX = attributes_dict.get('_xmipp_ShiftX')
-                    shiftY = attributes_dict.get('_xmipp_ShiftY')
-                elif prot_name in ('ProtMotionCorr', 'ProtRelionMotioncor'):
+                shiftX = attributes_dict.get('_xmipp_ShiftX')
+                shiftY = attributes_dict.get('_xmipp_ShiftY')
+                if not shiftX or not shiftY:
                     alignment = attributes_dict.get('_alignment')
-                    shiftX = alignment._xshifts
-                    shiftY = alignment._yshifts
-
+                    shiftX = getattr(alignment, "_xshifts", None)
+                    shiftY = getattr(alignment, "_yshifts", None)
                 norm = np.linalg.norm([shiftX, shiftY], axis=0)
                 avg_shifts.append(np.mean(norm))
                 max_shifts.append(np.max(norm))

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -280,11 +280,11 @@ class ProtOSCEM(EMProtocol):
         valid_file_keys = [key for key in file_keys if input_movies[key] is not None]
         for key in valid_file_keys:
             data = self.load_image_path(input_movies[key])
+            print(f'data gain: {data}')
 
-            # Normalize the data to 8-bit (0-255) range
-            min_val = np.min(data)
-            max_val = np.max(data)
-            normalized_data = 255 * (data - min_val) / (max_val - min_val)
+            p_low, p_high = np.percentile(data, [1, 99])
+            data_clip = np.clip(data, p_low, p_high)
+            normalized_data = 255 * (data_clip - p_low) / (p_high - p_low)
             normalized_data = normalized_data.astype(np.uint8)
 
             # Apply Histogram Equalization
@@ -992,7 +992,7 @@ class ProtOSCEM(EMProtocol):
     def load_image_path(self, path):
         ext = os.path.splitext(path)[1].lower()
         # MRC/MRCS
-        if ext in [".mrc", ".mrcs", ".gain"]:
+        if ext in [".mrc", ".mrcs"]:
             with mrcfile.open(path, 'r') as mrc:
                 return np.array(mrc.data, dtype=np.float32)
         # TIFF/TIF
@@ -1000,11 +1000,12 @@ class ProtOSCEM(EMProtocol):
             img = Image.open(path)
             arr = np.array(img, dtype=np.float32)
             return arr
-        # EER
-        elif ext == ".eer":
-            raise ValueError(
-                f"File {path} is EER."
-            )
+        # GAIN
+        elif ext == ".gain":
+            G = emlib.Image()
+            G.read(path)
+            data = G.getData()
+            return data
 
     def get_movie_alignment_descriptor(self):
         """

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -1017,6 +1017,7 @@ class ProtOSCEM(EMProtocol):
         descriptor_thing_dict = {}
         ################################ INPUT #############################################
         input_alignment = MovieAlignmentProt.getObjDict()
+        print(dir(MovieAlignmentProt))
         # List of keys to retrieve
         keys_to_retrieve = ['binFactor', 'maxResForCorrelation', 'gainRot', 'gainFlip']
 
@@ -1077,9 +1078,9 @@ class ProtOSCEM(EMProtocol):
         }
         frames_aligned = {key_mapping[key]: input_alignment[key] for key in keys_to_retrieve if
                           key in input_alignment and input_alignment[key] is not None}
-
-        if frames_aligned['frameN'] == 0:
-            frames_aligned['frameN'] = self.number_movies
+        if 'frameN' in frames_aligned:
+            if frames_aligned['frameN'] == 0:
+                frames_aligned['frameN'] = self.number_movies
 
         descriptor_thing_dict['frames_aligned'] = frames_aligned
 
@@ -1095,7 +1096,7 @@ class ProtOSCEM(EMProtocol):
                 if prot_name == 'XmippProtFlexAlign':
                     shiftX = attributes_dict.get('_xmipp_ShiftX')
                     shiftY = attributes_dict.get('_xmipp_ShiftY')
-                elif prot_name in ('ProtMotionCorr', 'ProtRelionMotioncorr'):
+                elif prot_name in ('ProtMotionCorr', 'ProtRelionMotioncor'):
                     alignment = attributes_dict.get('_alignment')
                     shiftX = alignment._xshifts
                     shiftY = alignment._yshifts

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -4,6 +4,8 @@ from os.path import abspath, join, dirname, splitext
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 from matplotlib import pyplot as plt
 import mrcfile
+import tifffile
+import cryoEER
 
 import pyworkflow.protocol.params as params
 import xmipp3
@@ -533,27 +535,37 @@ class ProtOSCEM(EMProtocol):
         parts = self.particles.get()
         mic_dict = {}
 
+        # Iterate over particles
         for index, item in enumerate(parts.iterItems()):
             micrograph_num = str(item._micId)
             sampling_rate_part = item._samplingRate.get()
-            sampling_rate_ctf = item._ctfModel._micObj._samplingRate.get()
-            scale = sampling_rate_part/sampling_rate_ctf
 
-            # coordinates scaled
-            coordinates_scaled = [item._coordinate._x.get() * scale, item._coordinate._y.get() * scale]
+            # Try to get CTF sampling rate
+            try:
+                sampling_rate_ctf = item._ctfModel._micObj._samplingRate.get()
+            except:
+                sampling_rate_ctf = None
 
-            # Key of dictionary is the micrograph ID
-            # If the key already exists in the dictionary, increment the count
-            # Otherwise, add the key with an initial count of 1
+            scale = sampling_rate_part / sampling_rate_ctf if sampling_rate_ctf else 1.0
+
+            # Coordinates are only used for micrograph examples
+            coordinates_scaled = [item._coordinate._x.get() * scale,
+                                  item._coordinate._y.get() * scale]
+
+            # Store info in mic_dict
             if micrograph_num in mic_dict:
                 mic_dict[micrograph_num]['particles_num'] += 1
-                mic_dict[micrograph_num]['coordinates'].append(coordinates_scaled)
-
+                mic_dict[micrograph_num].setdefault('coordinates', []).append(coordinates_scaled)
             else:
+                try:
+                    mic_path = item._ctfModel._micObj._filename.get()
+                except:
+                    mic_path = None
+
                 mic_dict[micrograph_num] = {
                     'particles_num': 1,
                     'coordinates': [coordinates_scaled],
-                    'mic_path': item._ctfModel._micObj._filename.get()
+                    'mic_path': mic_path
                 }
 
         # Calculate the mean particle values
@@ -574,65 +586,73 @@ class ProtOSCEM(EMProtocol):
         particles_hist = self.hist_path(hist_name)
         plt.savefig(particles_hist)
 
+        # Generate micrograph examples ONLY if micrographs exist
+        micrograph_examples_path = None
+        if self.micrographs.get() is not None:
+            try:
+                # Select micrographs for collage
+                mic_closest_to_mean = min(
+                    mic_dict.items(),
+                    key=lambda x: abs(x[1]['particles_num'] - mean_particles_values)
+                )[0]
+                mic_with_lowest_particles = min(mic_dict, key=lambda k: mic_dict[k]['particles_num'])
+                mic_with_highest_particles = max(mic_dict, key=lambda k: mic_dict[k]['particles_num'])
 
-        # Obtain 3 micrographs with particles drawn on them
-        # Retrieve mic ID of micrograph with higher, medium and lower number of particles:
-        mic_closest_to_mean = min(mic_dict.items(), key=lambda x: abs(x[1]['particles_num']- mean_particles_values))[0]
-        mic_with_lowest_particles = min(mic_dict, key=lambda k: mic_dict[k]['particles_num'])
-        mic_with_highest_particles = max(mic_dict, key=lambda k: mic_dict[k]['particles_num'])
+                mic_ids = [int(mic_with_highest_particles), int(mic_closest_to_mean), int(mic_with_lowest_particles)]
+                reduced_mics_dict = {
+                    mic_id: {
+                        "mic_path": mic_dict.get(str(mic_id), {}).get('mic_path'),
+                        "coordinates": mic_dict.get(str(mic_id), {}).get('coordinates', [])
+                    }
+                    for mic_id in mic_ids
+                }
 
-        mic_ids = [int(mic_with_highest_particles), int(mic_closest_to_mean), int(mic_with_lowest_particles)]
+                # Draw particles in images
+                images = [] # List to store the images after drawing particles
+                for micrograph, values in reduced_mics_dict.items():
+                    if not values['mic_path']:
+                        continue
 
-        # Dict to store the path and coordinates of the 3 micrographs keeping mic_ids order
-        reduced_mics_dict = {mic_id: {"mic_path": mic_dict.get(str(mic_id), {}).get('mic_path', 0), #None,
-                                      "coordinates": mic_dict.get(str(mic_id), {}).get('coordinates', 0)
-                             #        "particles_num": mic_dict.get(str(mic_id), {}).get('particles_num', 0)
-                                       }
-                             for mic_id in mic_ids
-                                      }
+                    with mrcfile.open(values['mic_path'], permissive=True) as mrc:
+                        mrc_data = mrc.data
+                    mrc_normalized = 255 * (mrc_data - np.min(mrc_data)) / (np.max(mrc_data) - np.min(mrc_data))
+                    mrc_normalized = mrc_normalized.astype(np.uint8)
+                    image = Image.fromarray(mrc_normalized).convert('RGB')
 
-        # Draw particles in images
-        images = [] # List to store the images after drawing particles
-        for micrograph, values in reduced_mics_dict.items():
-            with mrcfile.open(values['mic_path'], permissive=True) as mrc:
-                mrc_data = mrc.data
-            mrc_normalized = 255 * (mrc_data - np.min(mrc_data)) / (np.max(mrc_data) - np.min(mrc_data))
-            mrc_normalized = mrc_normalized.astype(np.uint8)
-            image = Image.fromarray(mrc_normalized).convert('RGB')
+                    W_jpg, _ = image.size
+                    draw = ImageDraw.Draw(image)
+                    r = W_jpg / 256
 
-            W_jpg, _ = image.size
-            draw = ImageDraw.Draw(image)
-            r = W_jpg / 256
+                    for coord in values['coordinates']:
+                        x, y = coord
+                        draw.ellipse((x - r, y - r, x + r, y + r), fill=(0, 255, 0))
 
-            for coord in values['coordinates']:
-                x = coord[0]
-                y = coord[1]
-                draw.ellipse((x - r, y - r, x + r, y + r), fill=(0, 255, 0))
+                    images.append(image)
 
-            images.append(image)
+                if len(images) > 0:
+                    width, height = images[0].size
+                    collage = Image.new('RGB', (3 * width, height))
+                    for i, img in enumerate(images):
+                        collage.paste(img, (i * width, 0))
 
-        # Create collage
-        width, height = images[0].size
-        collage_width = 3 * width
-        collage_height = height
-        collage = Image.new('RGB', (collage_width, collage_height))
-        # Paste each image into the collage
-        for i, img in enumerate(images):
-            collage.paste(img, (i * width, 0))
+                    extra_folder = self._getExtraPath()
+                    micro_folder_name = 'Micro_examples'
+                    micro_folder_path = join(extra_folder, micro_folder_name)
+                    micro_name = 'micro_particles.jpg'
+                    micrograph_examples_path = join(micro_folder_name, micro_name)
+                    collage.save(join(micro_folder_path, micro_name))
+            except:
+                pass  # If anything fails, skip micrograph examples
 
-        extra_folder = self._getExtraPath()
-        micro_folder_name = 'Micro_examples'
-        micro_folder_path = join(extra_folder, micro_folder_name)
+        particles = {
+            "number_particles": sum(particle_counts),
+            "particles_per_micrograph": round(mean_particles_values, 1),
+            "particles_histogram": hist_name
+        }
 
-        micro_name = 'micro_particles.jpg'
-        micro_path = join(micro_folder_path, micro_name)
-        collage.save(micro_path)
-
-        particles = {"number_particles": sum(particle_counts),
-                     "particles_per_micrograph": round(mean_particles_values, 1),
-                     "particles_histogram": hist_name,
-                     "micrograph_examples": join(micro_folder_name, micro_name)
-                     }
+        # Include micrograph_examples only if generated
+        if micrograph_examples_path:
+            particles["micrograph_examples"] = micrograph_examples_path
 
         return particles
 

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -279,9 +279,7 @@ class ProtOSCEM(EMProtocol):
         file_keys = [_gainFile, _darkFile]
         valid_file_keys = [key for key in file_keys if input_movies[key] is not None]
         for key in valid_file_keys:
-            with mrcfile.open(input_movies[key], 'r') as mrc:
-                # Read the data from the MRC file
-                data = mrc.data
+            data = self.load_image_path(input_movies[key])
 
             # Normalize the data to 8-bit (0-255) range
             min_val = np.min(data)
@@ -392,21 +390,21 @@ class ProtOSCEM(EMProtocol):
 
         # To draw defocus value on image, we make images smaller and then larger
         # since the default font cannot be increased in size
-        with mrcfile.open(lowest_defocus_path, permissive=True) as mrc1:
-            data1 = mrc1.data
-            img1 = Image.fromarray(np.uint8(data1 / np.max(data1) * 255))
-            img1 = img1.convert('RGB')
-            img1_resized = self.resize_image(img1, scale=0.05)
-        with mrcfile.open(medium_defocus_path, permissive=True) as mrc2:
-            data2 = mrc2.data
-            img2 = Image.fromarray(np.uint8(data2 / np.max(data2) * 255))
-            img2 = img2.convert('RGB')
-            img2_resized = self.resize_image(img2, scale=0.05)
-        with mrcfile.open(highest_defocus_path, permissive=True) as mrc3:
-            data3 = mrc3.data
-            img3 = Image.fromarray(np.uint8(data3 / np.max(data3) * 255))
-            img3 = img3.convert('RGB')
-            img3_resized = self.resize_image(img3, scale=0.05)
+
+        data1 = self.load_image_path(lowest_defocus_path)
+        img1 = Image.fromarray(np.uint8(data1 / np.max(data1) * 255))
+        img1 = img1.convert('RGB')
+        img1_resized = self.resize_image(img1, scale=0.05)
+
+        data2 = self.load_image_path(medium_defocus_path)
+        img2 = Image.fromarray(np.uint8(data2 / np.max(data2) * 255))
+        img2 = img2.convert('RGB')
+        img2_resized = self.resize_image(img2, scale=0.05)
+
+        data3 = self.load_image_path(highest_defocus_path)
+        img3 = Image.fromarray(np.uint8(data3 / np.max(data3) * 255))
+        img3 = img3.convert('RGB')
+        img3_resized = self.resize_image(img3, scale=0.05)
 
 
         font = ImageFont.load_default()
@@ -611,8 +609,7 @@ class ProtOSCEM(EMProtocol):
                     if not values['mic_path']:
                         continue
 
-                    with mrcfile.open(values['mic_path'], permissive=True) as mrc:
-                        mrc_data = mrc.data
+                    mrc_data = self.load_image_path(values['mic_path'])
                     mrc_normalized = 255 * (mrc_data - np.min(mrc_data)) / (np.max(mrc_data) - np.min(mrc_data))
                     mrc_normalized = mrc_normalized.astype(np.uint8)
                     image = Image.fromarray(mrc_normalized).convert('RGB')
@@ -678,38 +675,38 @@ class ProtOSCEM(EMProtocol):
         # Saving images in .jpg, drawing number of particles on them
         particles_list = []
         img_filenames = []
-        with mrcfile.open(img_classes_file, 'r') as mrc:
-            data = mrc.data
-            for i, class_2D in enumerate(sorted_list_classes):
-                particles = class_2D.getSize()
-                particles_list.append(particles)
-                index = class_2D.getRepresentative().getIndex()
 
-                img = data[index - 1, :, :]
+        data = self.load_image_path(img_classes_file)
+        for i, class_2D in enumerate(sorted_list_classes):
+            particles = class_2D.getSize()
+            particles_list.append(particles)
+            index = class_2D.getRepresentative().getIndex()
 
-                img_normalized = 255 * (img - np.min(img)) / (np.max(img) - np.min(img))
-                img_normalized = img_normalized.astype(np.uint8)
-                image = Image.fromarray(img_normalized)
-                image = image.convert('RGB')
+            img = data[index - 1, :, :]
 
-                # Draw the number of particles on the images
-                draw = ImageDraw.Draw(image)
-                font = ImageFont.load_default()
-                position = (10, 10)
-                draw.text(position, str(particles), fill='#80FF00', font=font)
+            img_normalized = 255 * (img - np.min(img)) / (np.max(img) - np.min(img))
+            img_normalized = img_normalized.astype(np.uint8)
+            image = Image.fromarray(img_normalized)
+            image = image.convert('RGB')
 
-                # Saving images
-                new_img_filename = splitext(img_classes_file)[0] + f'_image_{i}.jpg'
-                image.save(new_img_filename)
-                img_filenames.append(new_img_filename)
+            # Draw the number of particles on the images
+            draw = ImageDraw.Draw(image)
+            font = ImageFont.load_default()
+            position = (10, 10)
+            draw.text(position, str(particles), fill='#80FF00', font=font)
 
-            # Creating collage in .jpg with all images ordered in descending order
-            images = [Image.open(filename) for filename in img_filenames]
+            # Saving images
+            new_img_filename = splitext(img_classes_file)[0] + f'_image_{i}.jpg'
+            image.save(new_img_filename)
+            img_filenames.append(new_img_filename)
 
-            output_folder = self._getExtraPath()
-            collage_filename = 'classes_2D.jpg'
-            collage_filepath = join(output_folder, collage_filename)
-            self.create_collage(images, collage_filepath)
+        # Creating collage in .jpg with all images ordered in descending order
+        images = [Image.open(filename) for filename in img_filenames]
+
+        output_folder = self._getExtraPath()
+        collage_filename = 'classes_2D.jpg'
+        collage_filepath = join(output_folder, collage_filename)
+        self.create_collage(images, collage_filepath)
 
         classes_2D = {"particles_per_2Dclass": particles_list,
                       "images_classes_2D": collage_filename}
@@ -905,82 +902,81 @@ class ProtOSCEM(EMProtocol):
                 file_name_without_suffix = file_name.split(':')[0]
                 file_name = file_name_without_suffix
 
-            with mrcfile.open(file_name, 'r') as mrc:
-                data = mrc.data
+            data = self.load_image_path(file_name)
 
-                ############################
-                ########## CLASSES #########
-                ############################
+            ############################
+            ########## CLASSES #########
+            ############################
 
-                particles = class_3D.getSize()
-                particles_list.append(particles)
+            particles = class_3D.getSize()
+            particles_list.append(particles)
 
-                mid_index = data.shape[0] // 2
+            mid_index = data.shape[0] // 2
 
-                img = data[mid_index, :, :]
+            img = data[mid_index, :, :]
 
-                img_normalized = 255 * (img - np.min(img)) / (np.max(img) - np.min(img))
-                img_normalized = img_normalized.astype(np.uint8)
-                image = Image.fromarray(img_normalized)
-                image = image.convert('RGB')
+            img_normalized = 255 * (img - np.min(img)) / (np.max(img) - np.min(img))
+            img_normalized = img_normalized.astype(np.uint8)
+            image = Image.fromarray(img_normalized)
+            image = image.convert('RGB')
 
-                # Draw the number of particles on the images
-                draw = ImageDraw.Draw(image)
-                font = ImageFont.load_default()
-                position = (10, 10)
-                draw.text(position, str(particles), fill='#80FF00', font=font)
+            # Draw the number of particles on the images
+            draw = ImageDraw.Draw(image)
+            font = ImageFont.load_default()
+            position = (10, 10)
+            draw.text(position, str(particles), fill='#80FF00', font=font)
 
-                new_img_filename = splitext(file_name)[0] + '.jpg'
-                image.save(new_img_filename)
-                img_filenames.append(new_img_filename)
+            new_img_filename = splitext(file_name)[0] + '.jpg'
+            image.save(new_img_filename)
+            img_filenames.append(new_img_filename)
 
-                #############################
-                ########## VOLUMES ##########
-                #############################
+            #############################
+            ########## VOLUMES ##########
+            #############################
 
-                # Volume size
-                size = data.shape
-                vol_size_list = [int(x) for x in size]
+            # Volume size
+            size = data.shape
+            vol_size_list = [int(x) for x in size]
 
-                # Getting orthogonal slices in X, Y and Z
-                # Folder to store orthogonal slices
-                orthogonal_slices_folder = f'orthogonal_slices_volume{i + 1}'
-                orthogonal_slices_path = join(classes3D_folder_path, orthogonal_slices_folder)
-                os.makedirs(orthogonal_slices_path, exist_ok=True)
+            # Getting orthogonal slices in X, Y and Z
+            # Folder to store orthogonal slices
+            orthogonal_slices_folder = f'orthogonal_slices_volume{i + 1}'
+            orthogonal_slices_path = join(classes3D_folder_path, orthogonal_slices_folder)
+            os.makedirs(orthogonal_slices_path, exist_ok=True)
 
-                self.orthogonalSlices(fnRoot=orthogonal_slices_path, map=data)
+            self.orthogonalSlices(fnRoot=orthogonal_slices_path, map=data)
 
-                # Getting 3 isosurface images
-                # Folder to store isosurface images
-                isosurface_images_folder = f'isosurface_images_volume{i + 1}'
-                isosurface_images_path = join(classes3D_folder_path, isosurface_images_folder)
-                os.makedirs(isosurface_images_path, exist_ok=True)
+            # Getting 3 isosurface images
+            # Folder to store isosurface images
+            isosurface_images_folder = f'isosurface_images_volume{i + 1}'
+            isosurface_images_path = join(classes3D_folder_path, isosurface_images_folder)
+            os.makedirs(isosurface_images_path, exist_ok=True)
 
-                th = int(self.threshold_classes3D.get())
-                volume_file_abspath = abspath(file_name)
-                front_view_img = 'front_view.jpg'
-                side_view_img = 'side_view.jpg'
-                top_view_img = 'top_view.jpg'
-                self.generate_isosurfaces(isosurface_images_path, volume_file_abspath,
-                                          th, front_view_img, side_view_img, top_view_img)
+            th = int(self.threshold_classes3D.get())
+            volume_file_abspath = abspath(file_name)
+            front_view_img = 'front_view.jpg'
+            side_view_img = 'side_view.jpg'
+            top_view_img = 'top_view.jpg'
+            self.generate_isosurfaces(isosurface_images_path, volume_file_abspath,
+                                      th, front_view_img, side_view_img, top_view_img)
 
-                # Dictionary fill in:
-                volume = {
-                    "size": vol_size_list,
-                    "orthogonal_slices": {
-                        "orthogonal_slices_X": join(classes_3D_folder_name, orthogonal_slices_folder,
-                                                    slices_x),
-                        "orthogonal_slices_Y": join(classes_3D_folder_name, orthogonal_slices_folder,
-                                                    slices_y),
-                        "orthogonal_slices_Z": join(classes_3D_folder_name, orthogonal_slices_folder,
-                                                    slices_z)},
-                    'isosurface_images': {
-                        'front_view': join(classes_3D_folder_name, isosurface_images_folder, front_view_img),
-                        'side_view': join(classes_3D_folder_name, isosurface_images_folder, side_view_img),
-                        'top_view': join(classes_3D_folder_name, isosurface_images_folder, top_view_img)
-                    }}
+            # Dictionary fill in:
+            volume = {
+                "size": vol_size_list,
+                "orthogonal_slices": {
+                    "orthogonal_slices_X": join(classes_3D_folder_name, orthogonal_slices_folder,
+                                                slices_x),
+                    "orthogonal_slices_Y": join(classes_3D_folder_name, orthogonal_slices_folder,
+                                                slices_y),
+                    "orthogonal_slices_Z": join(classes_3D_folder_name, orthogonal_slices_folder,
+                                                slices_z)},
+                'isosurface_images': {
+                    'front_view': join(classes_3D_folder_name, isosurface_images_folder, front_view_img),
+                    'side_view': join(classes_3D_folder_name, isosurface_images_folder, side_view_img),
+                    'top_view': join(classes_3D_folder_name, isosurface_images_folder, top_view_img)
+                }}
 
-                volumes_list.append(volume)
+            volumes_list.append(volume)
 
         # Creating collage in .jpg with all images ordered in descending order
         images = [Image.open(filename) for filename in img_filenames]
@@ -992,6 +988,23 @@ class ProtOSCEM(EMProtocol):
                       "images_classes_3D": join(classes_3D_folder_name, collage_filename),
                       "volumes": volumes_list}
         return classes_3D
+
+    def load_image_path(self, path):
+        ext = os.path.splitext(path)[1].lower()
+        # MRC/MRCS
+        if ext in [".mrc", ".mrcs"]:
+            with mrcfile.open(path, 'r') as mrc:
+                return np.array(mrc.data, dtype=np.float32)
+        # TIFF/TIF
+        elif ext in [".tif", ".tiff"]:
+            img = Image.open(path)
+            arr = np.array(img, dtype=np.float32)
+            return arr
+        # EER
+        elif ext == ".eer":
+            raise ValueError(
+                f"File {path} is EER."
+            )
 
     def get_movie_alignment_descriptor(self):
         """

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -280,7 +280,6 @@ class ProtOSCEM(EMProtocol):
         valid_file_keys = [key for key in file_keys if input_movies[key] is not None]
         for key in valid_file_keys:
             data = self.load_image_path(input_movies[key])
-            print(f'data gain: {data}')
 
             p_low, p_high = np.percentile(data, [1, 99])
             data_clip = np.clip(data, p_low, p_high)
@@ -1013,7 +1012,8 @@ class ProtOSCEM(EMProtocol):
         """
         ###### MOVIE ALIGNMENT DESCRIPTOR ######
         MovieAlignmentProt = self.movieAlignment.get()
-        movie_align = {'descriptor_name': MovieAlignmentProt.getClassName()}
+        prot_name = MovieAlignmentProt.getClassName()
+        movie_align = {'descriptor_name': prot_name}
         descriptor_thing_dict = {}
         ################################ INPUT #############################################
         input_alignment = MovieAlignmentProt.getObjDict()
@@ -1092,8 +1092,13 @@ class ProtOSCEM(EMProtocol):
             max_shifts = []
             for index, item in enumerate(output.iterItems()):
                 attributes_dict = dict(item.getAttributes())
-                shiftX = attributes_dict.get('_xmipp_ShiftX')
-                shiftY = attributes_dict.get('_xmipp_ShiftY')
+                if prot_name == 'XmippProtFlexAlign':
+                    shiftX = attributes_dict.get('_xmipp_ShiftX')
+                    shiftY = attributes_dict.get('_xmipp_ShiftY')
+                elif prot_name in ('ProtMotionCorr', 'ProtRelionMotioncorr'):
+                    alignment = attributes_dict.get('_alignment')
+                    shiftX = alignment._xshifts
+                    shiftY = alignment._yshifts
 
                 norm = np.linalg.norm([shiftX, shiftY], axis=0)
                 avg_shifts.append(np.mean(norm))

--- a/emfacilities/protocols/protocol_OSCEM_metadata.py
+++ b/emfacilities/protocols/protocol_OSCEM_metadata.py
@@ -4,8 +4,6 @@ from os.path import abspath, join, dirname, splitext
 from PIL import Image, ImageDraw, ImageFont, ImageOps
 from matplotlib import pyplot as plt
 import mrcfile
-import tifffile
-import cryoEER
 
 import pyworkflow.protocol.params as params
 import xmipp3
@@ -122,7 +120,7 @@ class ProtOSCEM(EMProtocol):
                       help="Initial volume",
                       allowsNull=True)
 
-        form.addParam('threshold_initVol', params.IntParam, default=-1,
+        form.addParam('threshold_initVol', params.FloatParam, default=-1.0,
                       label="Initial volume threshold",
                       help=threshold_help)
 
@@ -132,7 +130,7 @@ class ProtOSCEM(EMProtocol):
                       help="Set of 3D classes",
                       allowsNull=True)
 
-        form.addParam('threshold_classes3D', params.IntParam, default=-1,
+        form.addParam('threshold_classes3D', params.FloatParam, default=-1.0,
                       label="3D Classes threshold",
                       help=threshold_help)
 
@@ -142,7 +140,7 @@ class ProtOSCEM(EMProtocol):
                       help="Final volume",
                       allowsNull=True)
 
-        form.addParam('threshold_finalVol', params.IntParam, default=-1,
+        form.addParam('threshold_finalVol', params.FloatParam, default=-1.0,
                       label="Final volume threshold",
                       help=threshold_help)
 
@@ -152,7 +150,7 @@ class ProtOSCEM(EMProtocol):
                       help="Sharpened volume",
                       allowsNull=True)
 
-        form.addParam('threshold_sharpenedVol', params.IntParam, default=-1,
+        form.addParam('threshold_sharpenedVol', params.FloatParam, default=-1.0,
                       label="Sharpened volume threshold",
                       help=threshold_help)
 
@@ -162,7 +160,7 @@ class ProtOSCEM(EMProtocol):
                       help="Polished volume",
                       allowsNull=True)
 
-        form.addParam('threshold_polishedVol', params.IntParam, default=-1,
+        form.addParam('threshold_polishedVol', params.FloatParam, default=-1.0,
                       label="Polished volume threshold",
                       help=threshold_help)
 


### PR DESCRIPTION
In this PR I have updated the OSCEM protocol in order to fix some errors that ocurred when running it after the CryoEM Facility (simple processing) workflow. 
This updates include:

- updated the threshold for volumes to be a float instead of integer
- create a function to open images that detects if it comes from a .mr, .tif or .gain file
- if not having micrographs, not creating the micrographs example thumbail
- updated the way shifts in x and y where retrieved in the movie alingment and maxh shift protocols to adjust to different plugins (xmipp, motioncorr and relion)